### PR TITLE
📝 improve README for auto versioning and release log

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,28 +36,52 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
     flopha next-version --pattern "desktop@{major}.{minor}.{patch}"
     ```
 
-5.  Create a new version tag:
+5.  Auto-detect the next bump from conventional commits:
 
     ```
-    flopha next-version --pattern "desktop@{major}.{minor}.{patch} --create
+    flopha next-version --auto
     ```
 
-6.  Increment major version:
+6.  Override auto-detection with custom rules:
+
+    ```
+    flopha next-version --auto --rule 'major:BREAKING CHANGE' --rule 'minor:^feat'
+    ```
+
+7.  Create a pre-release version:
+
+    ```
+    flopha next-version --pre rc
+    ```
+
+8.  Create a new version tag:
+
+    ```
+    flopha next-version --pattern "desktop@{major}.{minor}.{patch}" --create
+    ```
+
+9.  Increment major version:
 
     ```
     flopha next-version --increment major
     ```
 
-7.  Use branch-based versioning:
+10.  Use branch-based versioning:
 
     ```
     flopha next-version --source branch
     ```
 
-8.  Create a new version branch:
+11.  Create a new version branch:
 
     ```
     flopha next-version --pattern "release/{major}.{minor}.{patch}" --source branch --create
+    ```
+
+12.  Show version history:
+
+    ```
+    flopha log --limit 10
     ```
 
 ## CLI Commands and Options
@@ -65,8 +89,7 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
 ### NextVersion
 
 Calculates and displays the next version based on the current version in the repository.
-
-#### Usage
+Aliases: `nv`
 
 #### Options
 
@@ -78,38 +101,66 @@ Calculates and displays the next version based on the current version in the rep
 
   Default: `patch`
 
+- `--auto`: Auto-detect the bump level from commit messages since the last tag. This currently works with tag-based versioning. Built-in conventional commit behavior is:
+
+  - `BREAKING CHANGE` or `BREAKING-CHANGE` -> `major`
+  - `<type>!:` or `<type>(<scope>)!:` -> `major`
+  - `feat:` or `feat(scope):` -> `minor`
+  - anything else -> `patch`
+
+- `--rule <LEVEL:PATTERN>`: Define custom bump rules used with `--auto`. Repeatable. When any `--rule` flags are provided, they replace the built-in conventional commit rules entirely.
+
 - `-p`, `--pattern <PATTERN>`: Specify a custom pattern for version matching and generation. Use placeholders `{major}`, `{minor}`, and `{patch}`. Example patterns:
 
   - `v{major}.{minor}.{patch}`
   - `release-{major}.{minor}.{patch}`
 
-- `-v`, `--verbose`: Enable verbose output for detailed information.
+- `--pre <CHANNEL>`: Create a pre-release tag on the given channel. Example: `--pre alpha` produces `v1.2.3-alpha.1`.
 
 - `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
 
   - `tag` (default)
   - `branch`
 
-- `-c`, `--create`: Creates a new tag or branch
+- `-c`, `--create`: Create the next tag or branch in Git.
 
 ### LastVersion
 
 Retrieves and displays the most recent version tag or branch in the repository that matches a specified pattern.
-
-#### Usage
+Aliases: `lv`
 
 #### Options
 
 - `-p`, `--pattern <PATTERN>`: Get the last version based on a given pattern (e.g., `v{major}.{minor}.{patch}`).
 
-- `-v`, `--verbose`: Enable verbose output for detailed information.
+- `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
+
+  - `tag` (default)
+  - `branch`
+
+- `-c`, `--checkout`: Check out the last matching version.
+
+### Log
+
+Shows matching versions. In tag mode, it also includes tag dates and the number of commits between releases.
+Aliases: `lg`
+
+#### Options
+
+- `-p`, `--pattern <PATTERN>`: Filter versions by a pattern such as `v{major}.{minor}.{patch}`.
 
 - `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
 
   - `tag` (default)
   - `branch`
 
-- `-c`, `--checkout`: Checks out the last version
+  Tag mode provides full timeline metadata. Branch mode still lists matching versions, but tag dates and commit counts are not available.
+
+- `-n`, `--limit <LIMIT>`: Limit the number of versions shown.
+
+### Global Options
+
+- `-v`, `--verbose`: Enable verbose output for detailed information.
 
 ## Why Choose flopha?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # flopha
 
-flopha is a powerful Git workflow tool designed to simplify version management and streamline your GitHub flow. It helps developers manage semantic versioning, automate tagging, and simplify branch management.
+flopha is a CLI for semantic versioning and Git release workflows. It helps teams calculate the next version, manage Git tags and release branches, generate pre-release versions, and automate version bumps from conventional commits.
+
+Use flopha when you want a lightweight release management tool for Git repositories without wiring up a larger release pipeline.
 
 ## Install
 
@@ -9,6 +11,14 @@ Shell (Mac, Linux):
 ```
 curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install.sh | sh
 ```
+
+## Features
+
+- Semantic versioning CLI for Git tags and release branches
+- Conventional commit auto-detection for major, minor, and patch bumps
+- Pre-release channel support for `alpha`, `beta`, and `rc` style versions
+- Custom version patterns for app releases, desktop builds, and monorepo naming
+- Version history output for release auditing and changelog workflows
 
 ## Quickstart
 
@@ -48,7 +58,7 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
     flopha next-version --auto --rule 'major:BREAKING CHANGE' --rule 'minor:^feat'
     ```
 
-7.  Create a pre-release version:
+7.  Preview a pre-release version:
 
     ```
     flopha next-version --pre rc
@@ -84,7 +94,7 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
     flopha log --limit 10
     ```
 
-## CLI Commands and Options
+## CLI Commands
 
 ### NextVersion
 
@@ -115,7 +125,7 @@ Aliases: `nv`
   - `v{major}.{minor}.{patch}`
   - `release-{major}.{minor}.{patch}`
 
-- `--pre <CHANNEL>`: Create a pre-release tag on the given channel. Example: `--pre alpha` produces `v1.2.3-alpha.1`.
+- `--pre <CHANNEL>`: Format the next version as a pre-release on the given channel. Example: `--pre alpha` produces `v1.2.3-alpha.1`.
 
 - `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
 
@@ -161,13 +171,6 @@ Aliases: `lg`
 ### Global Options
 
 - `-v`, `--verbose`: Enable verbose output for detailed information.
-
-## Why Choose flopha?
-
-- **Simplify Semantic Versioning**: Automate version calculations based on your preferred patterns.
-- **Streamline Git Workflows**: Easily manage tags and versions across multiple branches and projects.
-- **Flexible and Customizable**: Adapt to various versioning schemes and project structures.
-- **Boost Productivity**: Reduce manual version management tasks and potential errors.
 
 ## License
 


### PR DESCRIPTION
## Why
The README needed to better reflect what flopha is for and surface the project with clearer release-management terminology, while staying concise.

## Changes
- tighten the opening description around semantic versioning, Git tags, release branches, and conventional commits
- add a concise feature summary with higher-intent search terms
- clean up headings and wording so examples and option descriptions stay accurate