### PR TITLE
:sparkles: Add changelog command and --format json output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ regex = "1.5"
 thiserror = "1"
 log = "0.4"
 env_logger = "0.11"
+serde_json = "1"
 
 [dev-dependencies]
 url = "2.0"

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,28 @@ inputs:
     required: false
     default: ''
 
+  # -- changelog --------------------------------------------------------------
+  changelog:
+    description: >
+      Generate a changelog from commits since the previous tag and use it as
+      the GitHub Release body. Ignored unless create-release is true.
+      When both changelog and release-body are set, release-body wins.
+    required: false
+    default: 'false'
+  changelog-groups:
+    description: >
+      Custom changelog group rules, one per line, as 'TITLE:REGEX'.
+      When provided, replaces the built-in conventional-commit defaults entirely.
+      Example: "Breaking Changes:BREAKING CHANGE\nFeatures:^feat"
+    required: false
+    default: ''
+  changelog-other:
+    description: >
+      Title for commits that match no group (default: "Other Changes").
+      Pass an empty string to suppress unmatched commits entirely.
+    required: false
+    default: ''
+
   # -- release ----------------------------------------------------------------
   create-release:
     description: 'Create a GitHub Release for the new tag.'
@@ -88,6 +110,9 @@ outputs:
   release-url:
     description: 'URL of the GitHub Release. Empty when create-release is false or dry-run is true.'
     value: ${{ steps.run.outputs.release-url }}
+  changelog:
+    description: 'Generated changelog in Markdown. Empty when changelog input is false.'
+    value: ${{ steps.run.outputs.changelog }}
 
 # ── steps ────────────────────────────────────────────────────────────────────
 
@@ -119,6 +144,9 @@ runs:
         INPUT_PRE: ${{ inputs.pre }}
         INPUT_RULE: ${{ inputs.rule }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_CHANGELOG: ${{ inputs.changelog }}
+        INPUT_CHANGELOG_GROUPS: ${{ inputs.changelog-groups }}
+        INPUT_CHANGELOG_OTHER: ${{ inputs.changelog-other }}
         INPUT_CREATE_RELEASE: ${{ inputs.create-release }}
         INPUT_DRAFT: ${{ inputs.draft }}
         INPUT_RELEASE_TITLE: ${{ inputs.release-title }}

--- a/action.yml
+++ b/action.yml
@@ -41,9 +41,10 @@ inputs:
   # -- changelog --------------------------------------------------------------
   changelog:
     description: >
-      Generate a changelog from commits since the previous tag and use it as
-      the GitHub Release body. Ignored unless create-release is true.
-      When both changelog and release-body are set, release-body wins.
+      Generate a changelog from commits since the previous tag.
+      The result is always available as the `changelog` output regardless of
+      other settings. When `create-release` is true and `release-body` is not
+      set, the changelog is also used as the GitHub Release body.
     required: false
     default: 'false'
   changelog-groups:
@@ -54,11 +55,13 @@ inputs:
     required: false
     default: ''
   changelog-other:
-    description: >
-      Title for commits that match no group (default: "Other Changes").
-      Pass an empty string to suppress unmatched commits entirely.
+    description: 'Title for commits that match no group. Default: "Other Changes".'
     required: false
     default: ''
+  changelog-suppress-other:
+    description: 'Set to true to omit commits that match no group entirely.'
+    required: false
+    default: 'false'
 
   # -- release ----------------------------------------------------------------
   create-release:
@@ -111,7 +114,7 @@ outputs:
     description: 'URL of the GitHub Release. Empty when create-release is false or dry-run is true.'
     value: ${{ steps.run.outputs.release-url }}
   changelog:
-    description: 'Generated changelog in Markdown. Empty when changelog input is false.'
+    description: 'Generated changelog text (Markdown by default). Empty when changelog input is false.'
     value: ${{ steps.run.outputs.changelog }}
 
 # ── steps ────────────────────────────────────────────────────────────────────
@@ -147,6 +150,7 @@ runs:
         INPUT_CHANGELOG: ${{ inputs.changelog }}
         INPUT_CHANGELOG_GROUPS: ${{ inputs.changelog-groups }}
         INPUT_CHANGELOG_OTHER: ${{ inputs.changelog-other }}
+        INPUT_CHANGELOG_SUPPRESS_OTHER: ${{ inputs.changelog-suppress-other }}
         INPUT_CREATE_RELEASE: ${{ inputs.create-release }}
         INPUT_DRAFT: ${{ inputs.draft }}
         INPUT_RELEASE_TITLE: ${{ inputs.release-title }}

--- a/action/run.sh
+++ b/action/run.sh
@@ -34,9 +34,13 @@ if [ "$INPUT_DRY_RUN" = "true" ]; then
   NEW_TAG=$(flopha next-version "${ARGS[@]}")
   echo "tag=$NEW_TAG"         >> "$GITHUB_OUTPUT"
   echo "release-url="         >> "$GITHUB_OUTPUT"
+  echo "changelog="           >> "$GITHUB_OUTPUT"
   echo "Dry run — next tag would be: $NEW_TAG"
   exit 0
 fi
+
+# ── capture previous tag before creating the new one ─────────────────────────
+PREV_TAG=$(flopha last-version --pattern "$INPUT_PATTERN" --format json | jq -r '.version // empty')
 
 # ── create and push the version tag ─────────────────────────────────────────
 NEW_TAG=$(flopha next-version "${ARGS[@]}" --create)
@@ -51,6 +55,25 @@ fi
 echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
 echo "Created and pushed tag: $NEW_TAG"
 
+# ── optionally generate changelog ────────────────────────────────────────────
+GENERATED_CHANGELOG=""
+if [ "$INPUT_CHANGELOG" = "true" ] && [ -n "$PREV_TAG" ]; then
+  CL_ARGS=(--from "$PREV_TAG" --to "$NEW_TAG")
+  if [ -n "$INPUT_CHANGELOG_GROUPS" ]; then
+    while IFS= read -r grp; do
+      [ -n "$grp" ] && CL_ARGS+=(--group "$grp")
+    done <<< "$INPUT_CHANGELOG_GROUPS"
+  fi
+  [ -n "$INPUT_CHANGELOG_OTHER" ] && CL_ARGS+=(--other "$INPUT_CHANGELOG_OTHER")
+  GENERATED_CHANGELOG=$(flopha changelog "${CL_ARGS[@]}")
+fi
+# Emit changelog output (may be empty)
+{
+  echo "changelog<<__FLOPHA_EOF__"
+  printf '%s' "$GENERATED_CHANGELOG"
+  echo "__FLOPHA_EOF__"
+} >> "$GITHUB_OUTPUT"
+
 # ── optionally create a GitHub Release ──────────────────────────────────────
 if [ "$INPUT_CREATE_RELEASE" != "true" ]; then
   echo "release-url=" >> "$GITHUB_OUTPUT"
@@ -64,8 +87,11 @@ RELEASE_ARGS+=(--title "${INPUT_RELEASE_TITLE:-$NEW_TAG}")
 [ -n "$INPUT_PRE" ]         && RELEASE_ARGS+=(--prerelease)
 
 # --notes and --generate-notes are mutually exclusive in gh CLI
+# Priority: release-body > generated changelog > generate-notes
 if [ -n "$INPUT_RELEASE_BODY" ]; then
   RELEASE_ARGS+=(--notes "$INPUT_RELEASE_BODY")
+elif [ -n "$GENERATED_CHANGELOG" ]; then
+  RELEASE_ARGS+=(--notes "$GENERATED_CHANGELOG")
 elif [ "$INPUT_GENERATE_RELEASE_NOTES" = "true" ]; then
   RELEASE_ARGS+=(--generate-notes)
 fi

--- a/action/run.sh
+++ b/action/run.sh
@@ -64,14 +64,20 @@ if [ "$INPUT_CHANGELOG" = "true" ] && [ -n "$PREV_TAG" ]; then
       [ -n "$grp" ] && CL_ARGS+=(--group "$grp")
     done <<< "$INPUT_CHANGELOG_GROUPS"
   fi
-  [ -n "$INPUT_CHANGELOG_OTHER" ] && CL_ARGS+=(--other "$INPUT_CHANGELOG_OTHER")
+  if [ "$INPUT_CHANGELOG_SUPPRESS_OTHER" = "true" ]; then
+    CL_ARGS+=(--other "")
+  elif [ -n "$INPUT_CHANGELOG_OTHER" ]; then
+    CL_ARGS+=(--other "$INPUT_CHANGELOG_OTHER")
+  fi
   GENERATED_CHANGELOG=$(flopha changelog "${CL_ARGS[@]}")
 fi
-# Emit changelog output (may be empty)
+# Emit changelog output using a randomised delimiter so commit message content
+# cannot prematurely close the multiline GitHub Actions output block.
+CL_EOF="__FLOPHA_CL_${RANDOM}${RANDOM}__"
 {
-  echo "changelog<<__FLOPHA_EOF__"
-  printf '%s' "$GENERATED_CHANGELOG"
-  echo "__FLOPHA_EOF__"
+  echo "changelog<<${CL_EOF}"
+  printf '%s\n' "$GENERATED_CHANGELOG"
+  echo "${CL_EOF}"
 } >> "$GITHUB_OUTPUT"
 
 # ── optionally create a GitHub Release ──────────────────────────────────────

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -182,7 +182,9 @@ pub struct LogArgs {
 #[derive(Args, Debug)]
 pub struct ChangelogArgs {
     #[clap(
-        help = "Version tag to start the changelog from (default: latest version matching pattern)",
+        help = "Tag to start the changelog from (default: latest version matching pattern). \
+                Defines which commits are included — commits reachable from HEAD that are \
+                not ancestors of this tag.",
         long
     )]
     pub from: Option<String>,
@@ -228,8 +230,8 @@ pub struct ChangelogArgs {
     pub title: Option<String>,
     #[clap(
         help = "Target version label for this changelog entry (e.g. v1.2.3). \
-                The tag does not need to exist yet — this is purely for display. \
-                Exposed as {to} in the --title template.",
+                Display-only: does not affect which commits are included (use --from for that). \
+                The tag does not need to exist yet. Exposed as {to} in the --title template.",
         long
     )]
     pub to: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -201,6 +201,17 @@ pub struct ChangelogArgs {
     )]
     pub source: VersionSourceName,
     #[clap(
+        help = "Custom categorization rule as '<level>:<regex>' matched against commit messages. \
+                Repeatable; when any --rule flags are provided they replace the built-in \
+                conventional-commit defaults entirely. \
+                Levels: major (Breaking Changes) | minor (Features) | patch (Bug Fixes). \
+                Commits matching no rule appear under Other Changes. \
+                Example: --rule 'major:BREAKING' --rule 'minor:^feat' --rule 'patch:^fix'",
+        long,
+        value_name = "LEVEL:PATTERN"
+    )]
+    pub rule: Vec<String>,
+    #[clap(
         help = "Write the changelog to a file instead of stdout",
         long,
         short = 'o'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -201,16 +201,16 @@ pub struct ChangelogArgs {
     )]
     pub source: VersionSourceName,
     #[clap(
-        help = "Custom section definition as 'TITLE:REGEX'. Repeatable; sections appear \
-                in the order given. When any --section flags are provided they replace the \
-                built-in defaults entirely. Commits not matched by any section are collected \
-                under 'Other Changes'. The title may contain spaces; the regex starts after \
-                the first colon and may itself contain colons. \
-                Example: --section 'New Features:^feat' --section 'Fixes:^fix'",
+        help = "Group definition as 'TITLE:REGEX'. Repeatable; groups appear in the order \
+                given. When any --group flags are provided they replace the built-in defaults \
+                entirely. Commits not matched by any group are collected under 'Other Changes'. \
+                The title may contain spaces; the regex starts after the first colon and may \
+                itself contain colons. \
+                Example: --group 'New Features:^feat' --group 'Fixes:^fix'",
         long,
         value_name = "TITLE:PATTERN"
     )]
-    pub section: Vec<String>,
+    pub group: Vec<String>,
     #[clap(
         help = "Write the changelog to a file instead of stdout",
         long,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,17 @@ pub enum Commands {
         alias = "lg"
     )]
     Log(LogArgs),
+    #[clap(
+        about = "Generates a changelog from commits since the last (or a given) version. (alias: cl)",
+        alias = "cl"
+    )]
+    Changelog(ChangelogArgs),
+}
+
+#[derive(Debug, Clone, ValueEnum, PartialEq)]
+pub enum OutputFormat {
+    Text,
+    Json,
 }
 
 #[derive(Args, Debug)]
@@ -98,6 +109,14 @@ pub struct NextVersionArgs {
         default_value = "tag"
     )]
     pub source: VersionSourceName,
+    #[clap(
+        help = "Output format: text (default) or json",
+        long,
+        short = 'f',
+        value_enum,
+        default_value = "text"
+    )]
+    pub format: OutputFormat,
 }
 
 #[derive(Args, Debug)]
@@ -118,6 +137,14 @@ pub struct LastVersionArgs {
     pub source: VersionSourceName,
     #[clap(help = "Checkout the last version", long, action)]
     pub checkout: bool,
+    #[clap(
+        help = "Output format: text (default) or json",
+        long,
+        short = 'f',
+        value_enum,
+        default_value = "text"
+    )]
+    pub format: OutputFormat,
 }
 
 #[derive(Args, Debug)]
@@ -142,6 +169,51 @@ pub struct LogArgs {
         short = 'n'
     )]
     pub limit: Option<usize>,
+    #[clap(
+        help = "Output format: text (default) or json",
+        long,
+        short = 'f',
+        value_enum,
+        default_value = "text"
+    )]
+    pub format: OutputFormat,
+}
+
+#[derive(Args, Debug)]
+pub struct ChangelogArgs {
+    #[clap(
+        help = "Version tag to start the changelog from (default: latest version matching pattern)",
+        long
+    )]
+    pub from: Option<String>,
+    #[clap(
+        help = "Pattern for version matching (e.g., 'v{major}.{minor}.{patch}')",
+        long,
+        short = 'p'
+    )]
+    pub pattern: Option<String>,
+    #[clap(
+        help = "Specify the source for versioning: tag (default) or branch",
+        long,
+        short = 's',
+        value_enum,
+        default_value = "tag"
+    )]
+    pub source: VersionSourceName,
+    #[clap(
+        help = "Write the changelog to a file instead of stdout",
+        long,
+        short = 'o'
+    )]
+    pub output: Option<String>,
+    #[clap(
+        help = "Output format: text (default) or json",
+        long,
+        short = 'f',
+        value_enum,
+        default_value = "text"
+    )]
+    pub format: OutputFormat,
 }
 
 #[derive(Debug, Clone, ValueEnum)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -212,6 +212,13 @@ pub struct ChangelogArgs {
     )]
     pub group: Vec<String>,
     #[clap(
+        help = "Title for commits that match no group (default: \"Other Changes\"). \
+                Pass an empty string to suppress unmatched commits entirely.",
+        long,
+        value_name = "TITLE"
+    )]
+    pub other: Option<String>,
+    #[clap(
         help = "Write the changelog to a file instead of stdout",
         long,
         short = 'o'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -226,12 +226,11 @@ pub struct ChangelogArgs {
     )]
     pub title: String,
     #[clap(
-        help = "When writing to a file, prepend the new changelog above existing content \
-                instead of overwriting it",
+        help = "Overwrite the output file instead of prepending to it",
         long,
         action
     )]
-    pub prepend: bool,
+    pub overwrite: bool,
     #[clap(
         help = "Write the changelog to a file instead of stdout",
         long,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -219,6 +219,20 @@ pub struct ChangelogArgs {
     )]
     pub other: Option<String>,
     #[clap(
+        help = "Title template for the changelog heading. Use {from} as a placeholder for \
+                the starting version tag (default: \"Changelog since {from}\")",
+        long,
+        default_value = "Changelog since {from}"
+    )]
+    pub title: String,
+    #[clap(
+        help = "When writing to a file, prepend the new changelog above existing content \
+                instead of overwriting it",
+        long,
+        action
+    )]
+    pub prepend: bool,
+    #[clap(
         help = "Write the changelog to a file instead of stdout",
         long,
         short = 'o'

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,7 +3,7 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use crate::versioning::Increment;
 
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(author, version, about, long_about = None, disable_version_flag = true)]
 pub struct Cli {
     #[clap(short = 'V', long = "version", action)]
     pub version: bool,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -219,12 +219,20 @@ pub struct ChangelogArgs {
     )]
     pub other: Option<String>,
     #[clap(
-        help = "Title template for the changelog heading. Use {from} as a placeholder for \
-                the starting version tag (default: \"Changelog since {from}\")",
-        long,
-        default_value = "Changelog since {from}"
+        help = "Title template for the changelog heading. Use {from} for the starting version \
+                and {to} for the target version. \
+                Defaults to \"Changes in {to}\" when --to is given, \
+                otherwise \"Changelog since {from}\".",
+        long
     )]
-    pub title: String,
+    pub title: Option<String>,
+    #[clap(
+        help = "Target version label for this changelog entry (e.g. v1.2.3). \
+                The tag does not need to exist yet — this is purely for display. \
+                Exposed as {to} in the --title template.",
+        long
+    )]
+    pub to: Option<String>,
     #[clap(
         help = "Overwrite the output file instead of prepending to it",
         long,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -201,16 +201,16 @@ pub struct ChangelogArgs {
     )]
     pub source: VersionSourceName,
     #[clap(
-        help = "Custom categorization rule as '<level>:<regex>' matched against commit messages. \
-                Repeatable; when any --rule flags are provided they replace the built-in \
-                conventional-commit defaults entirely. \
-                Levels: major (Breaking Changes) | minor (Features) | patch (Bug Fixes). \
-                Commits matching no rule appear under Other Changes. \
-                Example: --rule 'major:BREAKING' --rule 'minor:^feat' --rule 'patch:^fix'",
+        help = "Custom section definition as 'TITLE:REGEX'. Repeatable; sections appear \
+                in the order given. When any --section flags are provided they replace the \
+                built-in defaults entirely. Commits not matched by any section are collected \
+                under 'Other Changes'. The title may contain spaces; the regex starts after \
+                the first colon and may itself contain colons. \
+                Example: --section 'New Features:^feat' --section 'Fixes:^fix'",
         long,
-        value_name = "LEVEL:PATTERN"
+        value_name = "TITLE:PATTERN"
     )]
-    pub rule: Vec<String>,
+    pub section: Vec<String>,
     #[clap(
         help = "Write the changelog to a file instead of stdout",
         long,

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,4 +20,6 @@ pub enum FlophaError {
     MissingVersionComponent(String),
     #[error("invalid rule '{input}': {reason}")]
     InvalidRule { input: String, reason: String },
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
 }

--- a/src/gitutils.rs
+++ b/src/gitutils.rs
@@ -229,6 +229,39 @@ pub fn create_branch(repo: &Repository, name: &str, force: bool) -> Result<(), g
     Ok(())
 }
 
+pub struct CommitInfo {
+    pub short_id: String,
+    pub message: String,
+}
+
+/// Like [`commits_since_tag`] but also returns the short commit hash.
+pub fn commits_since_tag_with_info(
+    repo: &Repository,
+    tag_name: &str,
+) -> Result<Vec<CommitInfo>, git2::Error> {
+    let tag_obj = repo.revparse_single(&format!("refs/tags/{}", tag_name))?;
+    let tag_commit_oid = tag_obj.peel_to_commit()?.id();
+
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push_head()?;
+    revwalk.hide(tag_commit_oid)?;
+    revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+
+    let mut commits = Vec::new();
+    for oid in revwalk {
+        let oid = oid?;
+        let commit = repo.find_commit(oid)?;
+        if let Some(msg) = commit.message() {
+            let id_str = oid.to_string();
+            commits.push(CommitInfo {
+                short_id: id_str[..7.min(id_str.len())].to_string(),
+                message: msg.to_string(),
+            });
+        }
+    }
+    Ok(commits)
+}
+
 /// Returns commit messages for every commit reachable from HEAD that was made
 /// *after* the given tag (i.e., not included in the tagged commit or its ancestors).
 pub fn commits_since_tag(repo: &Repository, tag_name: &str) -> Result<Vec<String>, git2::Error> {

--- a/src/gitutils.rs
+++ b/src/gitutils.rs
@@ -239,7 +239,10 @@ pub fn commits_since_tag_with_info(
     repo: &Repository,
     tag_name: &str,
 ) -> Result<Vec<CommitInfo>, git2::Error> {
-    let tag_obj = repo.revparse_single(&format!("refs/tags/{}", tag_name))?;
+    let tag_obj = repo
+        .revparse_single(&format!("refs/tags/{}", tag_name))
+        .or_else(|_| repo.revparse_single(tag_name))
+        .map_err(|_| git2::Error::from_str(&format!("tag '{}' not found", tag_name)))?;
     let tag_commit_oid = tag_obj.peel_to_commit()?.id();
 
     let mut revwalk = repo.revwalk()?;
@@ -265,7 +268,10 @@ pub fn commits_since_tag_with_info(
 /// Returns commit messages for every commit reachable from HEAD that was made
 /// *after* the given tag (i.e., not included in the tagged commit or its ancestors).
 pub fn commits_since_tag(repo: &Repository, tag_name: &str) -> Result<Vec<String>, git2::Error> {
-    let tag_obj = repo.revparse_single(&format!("refs/tags/{}", tag_name))?;
+    let tag_obj = repo
+        .revparse_single(&format!("refs/tags/{}", tag_name))
+        .or_else(|_| repo.revparse_single(tag_name))
+        .map_err(|_| git2::Error::from_str(&format!("tag '{}' not found", tag_name)))?;
     let tag_commit_oid = tag_obj.peel_to_commit()?.id();
 
     let mut revwalk = repo.revwalk()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use clap::{CommandFactory, Parser};
 use flopha::cli::{Cli, Commands};
-use flopha::service::{last_version, log_versions, next_version};
+use flopha::service::{changelog, last_version, log_versions, next_version};
 
 fn main() {
     let cli = Cli::parse();
@@ -20,6 +20,7 @@ fn main() {
         Some(Commands::LastVersion(args)) => last_version(path, args),
         Some(Commands::NextVersion(args)) => next_version(path, args),
         Some(Commands::Log(args)) => log_versions(path, args).map(|_| None),
+        Some(Commands::Changelog(args)) => changelog(path, args).map(|_| None),
         None => {
             if cli.version {
                 println!("{}", env!("CARGO_PKG_VERSION"));

--- a/src/service.rs
+++ b/src/service.rs
@@ -5,6 +5,7 @@ use crate::error::FlophaError;
 use crate::gitutils;
 use crate::version_source::{BranchVersionSource, TagVersionSource, VersionSource};
 use crate::versioning::{self, BumpRule, Increment, Versioner};
+use crate::versioning::classify_commit;
 
 pub fn last_version(path: &Path, args: &LastVersionArgs) -> Result<Option<String>, FlophaError> {
     let repo = gitutils::get_repo(path)?;
@@ -229,6 +230,7 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
         }
     };
 
+    let rules = build_changelog_rules(&args.rule)?;
     let commits = gitutils::commits_since_tag_with_info(&repo, &from_tag).unwrap_or_default();
 
     let mut breaking: Vec<ChangelogEntry> = Vec::new();
@@ -237,19 +239,13 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     let mut other: Vec<ChangelogEntry> = Vec::new();
 
     for commit in &commits {
-        let cc = parse_conventional_commit(&commit.message);
-        let entry = ChangelogEntry {
-            subject: cc.subject.clone(),
-            hash: commit.short_id.clone(),
-        };
-        if cc.breaking {
-            breaking.push(entry);
-        } else if cc.type_ == "feat" {
-            features.push(entry);
-        } else if cc.type_ == "fix" {
-            fixes.push(entry);
-        } else {
-            other.push(entry);
+        let subject = commit.message.lines().next().unwrap_or("").trim().to_string();
+        let entry = ChangelogEntry { subject, hash: commit.short_id.clone() };
+        match classify_commit(&commit.message, &rules) {
+            Some(Increment::Major) => breaking.push(entry),
+            Some(Increment::Minor) => features.push(entry),
+            Some(Increment::Patch) => fixes.push(entry),
+            None => other.push(entry),
         }
     }
 
@@ -270,41 +266,6 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
 struct ChangelogEntry {
     subject: String,
     hash: String,
-}
-
-struct ParsedCommit {
-    type_: String,
-    subject: String,
-    breaking: bool,
-}
-
-fn parse_conventional_commit(message: &str) -> ParsedCommit {
-    use std::sync::OnceLock;
-    static RE: OnceLock<regex::Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| {
-        regex::Regex::new(r"(?m)^([a-z]+)(\([^)]+\))?(!)?\s*:\s*(.+)$").unwrap()
-    });
-
-    let first_line = message.lines().next().unwrap_or("").trim();
-    let has_breaking_footer =
-        message.contains("BREAKING CHANGE:") || message.contains("BREAKING-CHANGE:");
-
-    if let Some(caps) = re.captures(first_line) {
-        let type_ = caps.get(1).map_or("", |m| m.as_str()).to_string();
-        let breaking_bang = caps.get(3).is_some();
-        let subject = caps.get(4).map_or("", |m| m.as_str()).to_string();
-        ParsedCommit {
-            type_,
-            subject,
-            breaking: breaking_bang || has_breaking_footer,
-        }
-    } else {
-        ParsedCommit {
-            type_: String::new(),
-            subject: first_line.to_string(),
-            breaking: has_breaking_footer,
-        }
-    }
 }
 
 fn format_changelog_text(
@@ -427,6 +388,13 @@ fn is_leap(year: u32) -> bool {
 fn build_rules(raw_rules: &[String]) -> Result<Vec<BumpRule>, FlophaError> {
     if raw_rules.is_empty() {
         return Ok(versioning::conventional_bump_rules());
+    }
+    raw_rules.iter().map(|s| parse_bump_rule(s)).collect()
+}
+
+fn build_changelog_rules(raw_rules: &[String]) -> Result<Vec<BumpRule>, FlophaError> {
+    if raw_rules.is_empty() {
+        return Ok(versioning::conventional_changelog_rules());
     }
     raw_rules.iter().map(|s| parse_bump_rule(s)).collect()
 }
@@ -964,11 +932,35 @@ mod tests {
             from: Some("v1.0.0".to_string()),
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
+            rule: vec![],
             output: None,
             format: OutputFormat::Text,
         };
 
         // Should not error and should produce non-empty output.
+        changelog(td.path(), &args).unwrap();
+    }
+
+    #[test]
+    fn test_changelog_custom_rules() {
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, mut remote) = testutils::init_remote(&repo);
+
+        create_new_remote_tag(&repo, &mut remote, "v1.0.0", false);
+        gitutils::checkout_tag(&repo, "v1.0.0").unwrap();
+        gitutils::commit(&repo, "BUMP_MAJOR: api overhaul").unwrap();
+        gitutils::commit(&repo, "ADD: new endpoint").unwrap();
+
+        let args = ChangelogArgs {
+            from: Some("v1.0.0".to_string()),
+            pattern: Some("v{major}.{minor}.{patch}".to_string()),
+            source: VersionSourceName::Tag,
+            rule: vec!["major:BUMP_MAJOR:".to_string(), "minor:^ADD:".to_string()],
+            output: None,
+            format: OutputFormat::Text,
+        };
+
+        // Custom rules should categorize without error.
         changelog(td.path(), &args).unwrap();
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -333,8 +333,8 @@ fn parse_group_rule(s: &str) -> Result<GroupRule, FlophaError> {
 
 fn format_changelog_text(title: &str, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
     let mut out = format!("## {}\n", title);
-    for (title, entries) in groups {
-        out.push_str(&format!("\n### {}\n", title));
+    for (group_title, entries) in groups {
+        out.push_str(&format!("\n### {}\n", group_title));
         for e in entries {
             out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
         }
@@ -353,7 +353,7 @@ fn format_changelog_json(title: &str, from: &str, groups: &[(String, Vec<Changel
             serde_json::json!({"title": group_title, "entries": entries_val})
         })
         .collect();
-    serde_json::json!({"title": title, "from": from, "groups": groups_val}).to_string()
+    serde_json::json!({"title": title, "from": from, "groups": groups_val}).to_string() + "\n"
 }
 
 fn try_fetch_from_origin(repo: &git2::Repository) {

--- a/src/service.rs
+++ b/src/service.rs
@@ -231,7 +231,7 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
         }
     };
 
-    let section_rules = build_section_rules(&args.section)?;
+    let section_rules = build_section_rules(&args.group)?;
     let commits = gitutils::commits_since_tag_with_info(&repo, &from_tag).unwrap_or_default();
 
     // Pre-build ordered section labels from the rules (deduplicated).
@@ -952,7 +952,7 @@ mod tests {
             from: Some("v1.0.0".to_string()),
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
-            section: vec![],
+            group: vec![],
             output: None,
             format: OutputFormat::Text,
         };
@@ -975,7 +975,7 @@ mod tests {
             from: Some("v1.0.0".to_string()),
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
-            section: vec!["Breaking:BUMP_MAJOR:".to_string(), "Additions:^ADD:".to_string()],
+            group: vec!["Breaking:BUMP_MAJOR:".to_string(), "Additions:^ADD:".to_string()],
             output: None,
             format: OutputFormat::Text,
         };

--- a/src/service.rs
+++ b/src/service.rs
@@ -993,4 +993,63 @@ mod tests {
         let mut branch = repo.find_branch(branch, git2::BranchType::Local).unwrap();
         gitutils::push_branch(remote, &mut branch).unwrap();
     }
+
+    // ── JSON format tests ─────────────────────────────────────────────────────
+
+    #[test]
+    fn test_changelog_json_structure() {
+        let sections = vec![
+            ("Features".to_string(), vec![
+                ChangelogEntry { subject: "add search".to_string(), hash: "abc1234".to_string() },
+            ]),
+            ("Bug Fixes".to_string(), vec![
+                ChangelogEntry { subject: "fix crash".to_string(), hash: "def5678".to_string() },
+            ]),
+        ];
+        let json = format_changelog_json("v1.0.0", &sections);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+
+        assert_eq!(v["from"], "v1.0.0");
+        assert_eq!(v["sections"].as_array().unwrap().len(), 2);
+        assert_eq!(v["sections"][0]["title"], "Features");
+        assert_eq!(v["sections"][0]["entries"][0]["subject"], "add search");
+        assert_eq!(v["sections"][0]["entries"][0]["hash"], "abc1234");
+        assert_eq!(v["sections"][1]["title"], "Bug Fixes");
+    }
+
+    #[test]
+    fn test_changelog_json_escapes_special_chars() {
+        let sections = vec![
+            (r#"Section "A""#.to_string(), vec![
+                ChangelogEntry {
+                    subject: r#"feat: support "quoted" args and backslash \"#.to_string(),
+                    hash: "abc1234".to_string(),
+                },
+            ]),
+        ];
+        let json = format_changelog_json(r#"v1.0.0"edge"#, &sections);
+
+        // Must parse without error despite embedded quotes and backslashes.
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON with special chars");
+        assert_eq!(v["from"], r#"v1.0.0"edge"#);
+        assert_eq!(v["sections"][0]["title"], r#"Section "A""#);
+        assert_eq!(v["sections"][0]["entries"][0]["subject"], r#"feat: support "quoted" args and backslash \"#);
+    }
+
+    #[test]
+    fn test_changelog_json_empty_sections() {
+        let json = format_changelog_json("v1.0.0", &[]);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(v["from"], "v1.0.0");
+        assert!(v["sections"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_version_json_escapes_special_chars() {
+        // Verifies the serde_json::json! pattern used in last_version / next_version.
+        let tricky = r#"v1.0.0"snapshot""#;
+        let json = serde_json::json!({"version": tricky}).to_string();
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(v["version"], tricky);
+    }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -266,9 +266,13 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     }
 
     let title = match &args.title {
-        Some(t) => t
-            .replace("{from}", &from_tag)
-            .replace("{to}", args.to.as_deref().unwrap_or("")),
+        Some(t) => {
+            if t.contains("{to}") && args.to.is_none() {
+                log::warn!("--title contains {{to}} but --to was not supplied; placeholder will be empty");
+            }
+            t.replace("{from}", &from_tag)
+             .replace("{to}", args.to.as_deref().unwrap_or(""))
+        }
         None => match &args.to {
             Some(to) => format!("Changes in {}", to),
             None => format!("Changelog since {}", from_tag),
@@ -1036,7 +1040,7 @@ mod tests {
 
         assert_eq!(v["title"], "Changelog since v1.0.0");
         assert_eq!(v["from"], "v1.0.0");
-        assert!(v.get("to").is_none() || v["to"].is_null());
+        assert!(v.get("to").is_none());
         assert_eq!(v["groups"].as_array().unwrap().len(), 2);
         assert_eq!(v["groups"][0]["title"], "Features");
         assert_eq!(v["groups"][0]["entries"][0]["subject"], "add search");
@@ -1070,7 +1074,7 @@ mod tests {
         let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", None, &[]);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["from"], "v1.0.0");
-        assert!(v.get("to").is_none() || v["to"].is_null());
+        assert!(v.get("to").is_none());
         assert!(v["groups"].as_array().unwrap().is_empty());
     }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,7 +2,9 @@ use std::path::Path;
 
 use std::collections::HashMap;
 
-use crate::cli::{ChangelogArgs, LastVersionArgs, LogArgs, NextVersionArgs, OutputFormat, VersionSourceName};
+use crate::cli::{
+    ChangelogArgs, LastVersionArgs, LogArgs, NextVersionArgs, OutputFormat, VersionSourceName,
+};
 use crate::error::FlophaError;
 use crate::gitutils;
 use crate::version_source::{BranchVersionSource, TagVersionSource, VersionSource};
@@ -242,10 +244,25 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     let mut other: Vec<ChangelogEntry> = Vec::new();
 
     for commit in &commits {
-        let subject = commit.message.lines().next().unwrap_or("").trim().to_string();
-        let entry = ChangelogEntry { subject, hash: commit.short_id.clone() };
-        match group_rules.iter().find(|r| r.pattern.is_match(&commit.message)) {
-            Some(rule) => group_entries.entry(rule.title.clone()).or_default().push(entry),
+        let subject = commit
+            .message
+            .lines()
+            .next()
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        let entry = ChangelogEntry {
+            subject,
+            hash: commit.short_id.clone(),
+        };
+        match group_rules
+            .iter()
+            .find(|r| r.pattern.is_match(&commit.message))
+        {
+            Some(rule) => group_entries
+                .entry(rule.title.clone())
+                .or_default()
+                .push(entry),
             None => other.push(entry),
         }
     }
@@ -254,12 +271,15 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     let mut groups: Vec<(String, Vec<ChangelogEntry>)> = group_order
         .into_iter()
         .filter_map(|title| {
-            group_entries.remove(&title).filter(|e| !e.is_empty()).map(|e| (title, e))
+            group_entries
+                .remove(&title)
+                .filter(|e| !e.is_empty())
+                .map(|e| (title, e))
         })
         .collect();
     if !other.is_empty() {
         match args.other.as_deref() {
-            Some("") => {}  // suppress unmatched commits
+            Some("") => {} // suppress unmatched commits
             Some(title) => groups.push((title.to_string(), other)),
             None => groups.push(("Other Changes".to_string(), other)),
         }
@@ -268,10 +288,12 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     let title = match &args.title {
         Some(t) => {
             if t.contains("{to}") && args.to.is_none() {
-                log::warn!("--title contains {{to}} but --to was not supplied; placeholder will be empty");
+                log::warn!(
+                    "--title contains {{to}} but --to was not supplied; placeholder will be empty"
+                );
             }
             t.replace("{from}", &from_tag)
-             .replace("{to}", args.to.as_deref().unwrap_or(""))
+                .replace("{to}", args.to.as_deref().unwrap_or(""))
         }
         None => match &args.to {
             Some(to) => format!("Changes in {}", to),
@@ -323,7 +345,11 @@ impl GroupRule {
 
 fn default_changelog_groups() -> Vec<GroupRule> {
     vec![
-        GroupRule::new("Breaking Changes", r"BREAKING[- ]CHANGE|(?m)^[a-z]+(\([^)]+\))?!:").unwrap(),
+        GroupRule::new(
+            "Breaking Changes",
+            r"BREAKING[- ]CHANGE|(?m)^[a-z]+(\([^)]+\))?!:",
+        )
+        .unwrap(),
         GroupRule::new("Features", r"(?m)^feat(\([^)]+\))?:").unwrap(),
         GroupRule::new("Bug Fixes", r"(?m)^fix(\([^)]+\))?:").unwrap(),
     ]
@@ -358,7 +384,12 @@ fn format_changelog_text(title: &str, groups: &[(String, Vec<ChangelogEntry>)]) 
     out
 }
 
-fn format_changelog_json(title: &str, from: &str, to: Option<&str>, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
+fn format_changelog_json(
+    title: &str,
+    from: &str,
+    to: Option<&str>,
+    groups: &[(String, Vec<ChangelogEntry>)],
+) -> String {
     let groups_val: Vec<serde_json::Value> = groups
         .iter()
         .map(|(group_title, entries)| {
@@ -992,7 +1023,10 @@ mod tests {
             from: Some("v1.0.0".to_string()),
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
-            group: vec!["Breaking:BUMP_MAJOR:".to_string(), "Additions:^ADD:".to_string()],
+            group: vec![
+                "Breaking:BUMP_MAJOR:".to_string(),
+                "Additions:^ADD:".to_string(),
+            ],
             other: None,
             title: None,
             to: None,
@@ -1032,12 +1066,20 @@ mod tests {
     #[test]
     fn test_changelog_json_structure() {
         let groups = vec![
-            ("Features".to_string(), vec![
-                ChangelogEntry { subject: "add search".to_string(), hash: "abc1234".to_string() },
-            ]),
-            ("Bug Fixes".to_string(), vec![
-                ChangelogEntry { subject: "fix crash".to_string(), hash: "def5678".to_string() },
-            ]),
+            (
+                "Features".to_string(),
+                vec![ChangelogEntry {
+                    subject: "add search".to_string(),
+                    hash: "abc1234".to_string(),
+                }],
+            ),
+            (
+                "Bug Fixes".to_string(),
+                vec![ChangelogEntry {
+                    subject: "fix crash".to_string(),
+                    hash: "def5678".to_string(),
+                }],
+            ),
         ];
         let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", None, &groups);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
@@ -1054,23 +1096,31 @@ mod tests {
 
     #[test]
     fn test_changelog_json_escapes_special_chars() {
-        let groups = vec![
-            (r#"Group "A""#.to_string(), vec![
-                ChangelogEntry {
-                    subject: r#"feat: support "quoted" args and backslash \"#.to_string(),
-                    hash: "abc1234".to_string(),
-                },
-            ]),
-        ];
-        let json = format_changelog_json(r#"Release v1.0.0"edge""#, r#"v1.0.0"edge"#, Some(r#"v1.0.0"edge""#), &groups);
+        let groups = vec![(
+            r#"Group "A""#.to_string(),
+            vec![ChangelogEntry {
+                subject: r#"feat: support "quoted" args and backslash \"#.to_string(),
+                hash: "abc1234".to_string(),
+            }],
+        )];
+        let json = format_changelog_json(
+            r#"Release v1.0.0"edge""#,
+            r#"v1.0.0"edge"#,
+            Some(r#"v1.0.0"edge""#),
+            &groups,
+        );
 
         // Must parse without error despite embedded quotes and backslashes.
-        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON with special chars");
+        let v: serde_json::Value =
+            serde_json::from_str(&json).expect("valid JSON with special chars");
         assert_eq!(v["title"], r#"Release v1.0.0"edge""#);
         assert_eq!(v["from"], r#"v1.0.0"edge"#);
         assert_eq!(v["to"], r#"v1.0.0"edge""#);
         assert_eq!(v["groups"][0]["title"], r#"Group "A""#);
-        assert_eq!(v["groups"][0]["entries"][0]["subject"], r#"feat: support "quoted" args and backslash \"#);
+        assert_eq!(
+            v["groups"][0]["entries"][0]["subject"],
+            r#"feat: support "quoted" args and backslash \"#
+        );
     }
 
     #[test]
@@ -1084,11 +1134,13 @@ mod tests {
 
     #[test]
     fn test_changelog_json_with_to_field() {
-        let groups = vec![
-            ("Features".to_string(), vec![
-                ChangelogEntry { subject: "add search".to_string(), hash: "abc1234".to_string() },
-            ]),
-        ];
+        let groups = vec![(
+            "Features".to_string(),
+            vec![ChangelogEntry {
+                subject: "add search".to_string(),
+                hash: "abc1234".to_string(),
+            }],
+        )];
         let json = format_changelog_json("Changes in v1.1.0", "v1.0.0", Some("v1.1.0"), &groups);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["title"], "Changes in v1.1.0");

--- a/src/service.rs
+++ b/src/service.rs
@@ -261,7 +261,11 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
         })
         .collect();
     if !other.is_empty() {
-        sections.push(("Other Changes".to_string(), other));
+        match args.other.as_deref() {
+            Some("") => {}  // suppress unmatched commits
+            Some(title) => sections.push((title.to_string(), other)),
+            None => sections.push(("Other Changes".to_string(), other)),
+        }
     }
 
     let content = match args.format {
@@ -953,6 +957,7 @@ mod tests {
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
             group: vec![],
+            other: None,
             output: None,
             format: OutputFormat::Text,
         };
@@ -976,6 +981,7 @@ mod tests {
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
             group: vec!["Breaking:BUMP_MAJOR:".to_string(), "Additions:^ADD:".to_string()],
+            other: None,
             output: None,
             format: OutputFormat::Text,
         };

--- a/src/service.rs
+++ b/src/service.rs
@@ -273,7 +273,7 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     };
 
     if let Some(ref output_path) = args.output {
-        if args.prepend && std::path::Path::new(output_path).exists() {
+        if !args.overwrite && std::path::Path::new(output_path).exists() {
             let existing = std::fs::read_to_string(output_path)?;
             std::fs::write(output_path, format!("{}\n{}", content, existing))?;
         } else {
@@ -948,7 +948,7 @@ mod tests {
             group: vec![],
             other: None,
             title: "Changelog since {from}".to_string(),
-            prepend: false,
+            overwrite: false,
             output: None,
             format: OutputFormat::Text,
         };
@@ -974,7 +974,7 @@ mod tests {
             group: vec!["Breaking:BUMP_MAJOR:".to_string(), "Additions:^ADD:".to_string()],
             other: None,
             title: "Changelog since {from}".to_string(),
-            prepend: false,
+            overwrite: false,
             output: None,
             format: OutputFormat::Text,
         };

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,11 +1,12 @@
 use std::path::Path;
 
+use std::collections::HashMap;
+
 use crate::cli::{ChangelogArgs, LastVersionArgs, LogArgs, NextVersionArgs, OutputFormat, VersionSourceName};
 use crate::error::FlophaError;
 use crate::gitutils;
 use crate::version_source::{BranchVersionSource, TagVersionSource, VersionSource};
 use crate::versioning::{self, BumpRule, Increment, Versioner};
-use crate::versioning::classify_commit;
 
 pub fn last_version(path: &Path, args: &LastVersionArgs) -> Result<Option<String>, FlophaError> {
     let repo = gitutils::get_repo(path)?;
@@ -230,28 +231,42 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
         }
     };
 
-    let rules = build_changelog_rules(&args.rule)?;
+    let section_rules = build_section_rules(&args.section)?;
     let commits = gitutils::commits_since_tag_with_info(&repo, &from_tag).unwrap_or_default();
 
-    let mut breaking: Vec<ChangelogEntry> = Vec::new();
-    let mut features: Vec<ChangelogEntry> = Vec::new();
-    let mut fixes: Vec<ChangelogEntry> = Vec::new();
+    // Pre-build ordered section labels from the rules (deduplicated).
+    let mut section_order: Vec<String> = Vec::new();
+    for rule in &section_rules {
+        if !section_order.contains(&rule.title) {
+            section_order.push(rule.title.clone());
+        }
+    }
+    let mut section_entries: HashMap<String, Vec<ChangelogEntry>> = HashMap::new();
     let mut other: Vec<ChangelogEntry> = Vec::new();
 
     for commit in &commits {
         let subject = commit.message.lines().next().unwrap_or("").trim().to_string();
         let entry = ChangelogEntry { subject, hash: commit.short_id.clone() };
-        match classify_commit(&commit.message, &rules) {
-            Some(Increment::Major) => breaking.push(entry),
-            Some(Increment::Minor) => features.push(entry),
-            Some(Increment::Patch) => fixes.push(entry),
+        match section_rules.iter().find(|r| r.pattern.is_match(&commit.message)) {
+            Some(rule) => section_entries.entry(rule.title.clone()).or_default().push(entry),
             None => other.push(entry),
         }
     }
 
+    // Collect in rule-defined order, skipping empty sections.
+    let mut sections: Vec<(String, Vec<ChangelogEntry>)> = section_order
+        .into_iter()
+        .filter_map(|title| {
+            section_entries.remove(&title).filter(|e| !e.is_empty()).map(|e| (title, e))
+        })
+        .collect();
+    if !other.is_empty() {
+        sections.push(("Other Changes".to_string(), other));
+    }
+
     let content = match args.format {
-        OutputFormat::Json => format_changelog_json(&from_tag, &breaking, &features, &fixes, &other),
-        OutputFormat::Text => format_changelog_text(&from_tag, &breaking, &features, &fixes, &other),
+        OutputFormat::Json => format_changelog_json(&from_tag, &sections),
+        OutputFormat::Text => format_changelog_text(&from_tag, &sections),
     };
 
     if let Some(ref output_path) = args.output {
@@ -268,71 +283,83 @@ struct ChangelogEntry {
     hash: String,
 }
 
-fn format_changelog_text(
-    from: &str,
-    breaking: &[ChangelogEntry],
-    features: &[ChangelogEntry],
-    fixes: &[ChangelogEntry],
-    other: &[ChangelogEntry],
-) -> String {
+struct SectionRule {
+    title: String,
+    pattern: regex::Regex,
+}
+
+impl SectionRule {
+    fn new(title: &str, pattern: &str) -> Result<Self, regex::Error> {
+        Ok(Self {
+            title: title.to_string(),
+            pattern: regex::Regex::new(pattern)?,
+        })
+    }
+}
+
+fn default_changelog_sections() -> Vec<SectionRule> {
+    vec![
+        SectionRule::new("Breaking Changes", r"BREAKING[- ]CHANGE|(?m)^[a-z]+(\([^)]+\))?!:").unwrap(),
+        SectionRule::new("Features", r"(?m)^feat(\([^)]+\))?:").unwrap(),
+        SectionRule::new("Bug Fixes", r"(?m)^fix(\([^)]+\))?:").unwrap(),
+    ]
+}
+
+fn build_section_rules(raw: &[String]) -> Result<Vec<SectionRule>, FlophaError> {
+    if raw.is_empty() {
+        return Ok(default_changelog_sections());
+    }
+    raw.iter().map(|s| parse_section_rule(s)).collect()
+}
+
+fn parse_section_rule(s: &str) -> Result<SectionRule, FlophaError> {
+    let (title, pattern) = s.split_once(':').ok_or_else(|| FlophaError::InvalidRule {
+        input: s.to_string(),
+        reason: "expected format 'TITLE:PATTERN'".to_string(),
+    })?;
+    SectionRule::new(title, pattern).map_err(|e| FlophaError::InvalidRule {
+        input: s.to_string(),
+        reason: format!("invalid regex: {}", e),
+    })
+}
+
+fn format_changelog_text(from: &str, sections: &[(String, Vec<ChangelogEntry>)]) -> String {
     let mut out = format!("## Changelog since {}\n", from);
-
-    if !breaking.is_empty() {
-        out.push_str("\n### Breaking Changes\n");
-        for e in breaking {
+    for (title, entries) in sections {
+        out.push_str(&format!("\n### {}\n", title));
+        for e in entries {
             out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
         }
     }
-    if !features.is_empty() {
-        out.push_str("\n### Features\n");
-        for e in features {
-            out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
-        }
-    }
-    if !fixes.is_empty() {
-        out.push_str("\n### Bug Fixes\n");
-        for e in fixes {
-            out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
-        }
-    }
-    if !other.is_empty() {
-        out.push_str("\n### Other Changes\n");
-        for e in other {
-            out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
-        }
-    }
-
     out
 }
 
-fn format_changelog_json(
-    from: &str,
-    breaking: &[ChangelogEntry],
-    features: &[ChangelogEntry],
-    fixes: &[ChangelogEntry],
-    other: &[ChangelogEntry],
-) -> String {
-    fn entries_to_json(entries: &[ChangelogEntry]) -> String {
+fn format_changelog_json(from: &str, sections: &[(String, Vec<ChangelogEntry>)]) -> String {
+    fn entries_json(entries: &[ChangelogEntry]) -> String {
         let items: Vec<String> = entries
             .iter()
-            .map(|e| {
-                format!(
-                    "{{\"subject\":{},\"hash\":\"{}\"}}",
-                    serde_json::Value::String(e.subject.clone()),
-                    e.hash
-                )
-            })
+            .map(|e| format!(
+                "{{\"subject\":{},\"hash\":\"{}\"}}",
+                serde_json::Value::String(e.subject.clone()),
+                e.hash
+            ))
             .collect();
         format!("[{}]", items.join(","))
     }
 
+    let sections_json: Vec<String> = sections
+        .iter()
+        .map(|(title, entries)| format!(
+            "{{\"title\":{},\"entries\":{}}}",
+            serde_json::Value::String(title.clone()),
+            entries_json(entries)
+        ))
+        .collect();
+
     format!(
-        "{{\"from\":\"{}\",\"breaking_changes\":{},\"features\":{},\"fixes\":{},\"other\":{}}}",
+        "{{\"from\":\"{}\",\"sections\":[{}]}}",
         from,
-        entries_to_json(breaking),
-        entries_to_json(features),
-        entries_to_json(fixes),
-        entries_to_json(other),
+        sections_json.join(",")
     )
 }
 
@@ -388,13 +415,6 @@ fn is_leap(year: u32) -> bool {
 fn build_rules(raw_rules: &[String]) -> Result<Vec<BumpRule>, FlophaError> {
     if raw_rules.is_empty() {
         return Ok(versioning::conventional_bump_rules());
-    }
-    raw_rules.iter().map(|s| parse_bump_rule(s)).collect()
-}
-
-fn build_changelog_rules(raw_rules: &[String]) -> Result<Vec<BumpRule>, FlophaError> {
-    if raw_rules.is_empty() {
-        return Ok(versioning::conventional_changelog_rules());
     }
     raw_rules.iter().map(|s| parse_bump_rule(s)).collect()
 }
@@ -932,7 +952,7 @@ mod tests {
             from: Some("v1.0.0".to_string()),
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
-            rule: vec![],
+            section: vec![],
             output: None,
             format: OutputFormat::Text,
         };
@@ -955,7 +975,7 @@ mod tests {
             from: Some("v1.0.0".to_string()),
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
-            rule: vec!["major:BUMP_MAJOR:".to_string(), "minor:^ADD:".to_string()],
+            section: vec!["Breaking:BUMP_MAJOR:".to_string(), "Additions:^ADD:".to_string()],
             output: None,
             format: OutputFormat::Text,
         };

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use crate::cli::{LastVersionArgs, LogArgs, NextVersionArgs, VersionSourceName};
+use crate::cli::{ChangelogArgs, LastVersionArgs, LogArgs, NextVersionArgs, OutputFormat, VersionSourceName};
 use crate::error::FlophaError;
 use crate::gitutils;
 use crate::version_source::{BranchVersionSource, TagVersionSource, VersionSource};
@@ -15,7 +15,10 @@ pub fn last_version(path: &Path, args: &LastVersionArgs) -> Result<Option<String
         .unwrap_or("v{major}.{minor}.{patch}".to_string());
     let versioner = versioner_factory(&repo, pattern, &args.source);
     if let Some(version) = versioner.last_version() {
-        println!("{}", version.tag);
+        match args.format {
+            OutputFormat::Json => println!("{{\"version\":\"{}\"}}", version.tag),
+            OutputFormat::Text => println!("{}", version.tag),
+        }
 
         if args.checkout {
             let version_source = version_source_factory(&args.source);
@@ -24,7 +27,10 @@ pub fn last_version(path: &Path, args: &LastVersionArgs) -> Result<Option<String
 
         Ok(Some(version.tag))
     } else {
-        println!("No version found");
+        match args.format {
+            OutputFormat::Json => println!("null"),
+            OutputFormat::Text => println!("No version found"),
+        }
         Ok(None)
     }
 }
@@ -40,7 +46,6 @@ pub fn next_version(path: &Path, args: &NextVersionArgs) -> Result<Option<String
     let version_source = version_source_factory(&args.source);
     let versioner = Versioner::new(version_source.fetch_all(&repo), pattern);
 
-    // Determine increment level, honouring --auto if set.
     let increment = if args.auto {
         let rules = build_rules(&args.rule)?;
         match versioner.last_version() {
@@ -60,19 +65,24 @@ pub fn next_version(path: &Path, args: &NextVersionArgs) -> Result<Option<String
     let next = match versioner.next_version(increment)? {
         Some(v) => v,
         None => {
-            println!("No version found");
+            match args.format {
+                OutputFormat::Json => println!("null"),
+                OutputFormat::Text => println!("No version found"),
+            }
             return Ok(None);
         }
     };
 
-    // If a pre-release channel was requested, compute the pre-release tag.
     let final_tag = if let Some(channel) = &args.pre {
         pre_release_tag(&next.tag, channel, &repo)
     } else {
         next.tag.clone()
     };
 
-    println!("{}", final_tag);
+    match args.format {
+        OutputFormat::Json => println!("{{\"version\":\"{}\"}}", final_tag),
+        OutputFormat::Text => println!("{}", final_tag),
+    }
 
     if args.create {
         version_source.create(&repo, &final_tag)?;
@@ -114,7 +124,6 @@ pub fn log_versions(path: &Path, args: &LogArgs) -> Result<(), FlophaError> {
     let versioner = versioner_factory(&repo, pattern, &args.source);
 
     let mut versions = versioner.all_versions();
-    // Show newest first.
     versions.reverse();
 
     if let Some(limit) = args.limit {
@@ -122,52 +131,248 @@ pub fn log_versions(path: &Path, args: &LogArgs) -> Result<(), FlophaError> {
     }
 
     if versions.is_empty() {
-        println!("No versions found");
+        match args.format {
+            OutputFormat::Json => println!("[]"),
+            OutputFormat::Text => println!("No versions found"),
+        }
         return Ok(());
     }
 
-    // Collect display rows: (tag, date_str, commit_count_str)
-    let mut rows: Vec<(String, String, String)> = Vec::new();
+    // Collect display rows: (tag, date_str, commit_count)
+    let mut rows: Vec<(String, String, usize)> = Vec::new();
     for (i, version) in versions.iter().enumerate() {
         let date_str = gitutils::tag_commit_time(&repo, &version.tag)
             .map(format_date)
             .unwrap_or_else(|_| "unknown".to_string());
 
-        // Count commits between this version and the next older one.
-        let commit_info = if i + 1 < versions.len() {
+        let commit_count = if i + 1 < versions.len() {
             let prev = &versions[i + 1];
             let from_oid = gitutils::tag_commit_oid(&repo, &prev.tag).ok();
             let to_oid = gitutils::tag_commit_oid(&repo, &version.tag).ok();
-            let count = match (from_oid, to_oid) {
+            match (from_oid, to_oid) {
                 (Some(from), Some(to)) => {
                     gitutils::count_commits_between(&repo, from, to).unwrap_or(0)
                 }
                 _ => 0,
-            };
-            format!("{} commit{}", count, if count == 1 { "" } else { "s" })
+            }
         } else {
-            // Oldest release: no prior tag boundary exists, so showing a raw count would
-            // include the entire project history and be misleading.
-            "\u{2014}".to_string()
+            0
         };
 
-        rows.push((version.tag.clone(), date_str, commit_info));
+        rows.push((version.tag.clone(), date_str, commit_count));
     }
 
-    // Align columns.
-    let tag_width = rows.iter().map(|(t, _, _)| t.len()).max().unwrap_or(0);
-    let date_width = rows.iter().map(|(_, d, _)| d.len()).max().unwrap_or(0);
+    match args.format {
+        OutputFormat::Json => {
+            let entries: Vec<String> = rows
+                .iter()
+                .enumerate()
+                .map(|(i, (tag, date, count))| {
+                    let commits_val = if i + 1 < rows.len() {
+                        count.to_string()
+                    } else {
+                        "null".to_string()
+                    };
+                    format!(
+                        "{{\"version\":\"{}\",\"date\":\"{}\",\"commits\":{}}}",
+                        tag, date, commits_val
+                    )
+                })
+                .collect();
+            println!("[{}]", entries.join(","));
+        }
+        OutputFormat::Text => {
+            let tag_width = rows.iter().map(|(t, _, _)| t.len()).max().unwrap_or(0);
+            let date_width = rows.iter().map(|(_, d, _)| d.len()).max().unwrap_or(0);
 
-    for (tag, date, commits) in &rows {
-        let padded_date = format!("{:<date_width$}", date, date_width = date_width);
-        println!(
-            "  {:<tag_width$}  {SEP}  {padded_date}  {SEP}  {commits}",
-            tag,
-            tag_width = tag_width,
-        );
+            for (i, (tag, date, count)) in rows.iter().enumerate() {
+                let commit_info = if i + 1 < rows.len() {
+                    format!("{} commit{}", count, if *count == 1 { "" } else { "s" })
+                } else {
+                    "\u{2014}".to_string()
+                };
+                let padded_date = format!("{:<date_width$}", date, date_width = date_width);
+                println!(
+                    "  {:<tag_width$}  {SEP}  {padded_date}  {SEP}  {commit_info}",
+                    tag,
+                    tag_width = tag_width,
+                );
+            }
+        }
     }
 
     Ok(())
+}
+
+pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
+    let repo = gitutils::get_repo(path)?;
+    try_fetch_from_origin(&repo);
+
+    let pattern = args
+        .pattern
+        .clone()
+        .unwrap_or("v{major}.{minor}.{patch}".to_string());
+
+    let from_tag = if let Some(ref from) = args.from {
+        from.clone()
+    } else {
+        let versioner = versioner_factory(&repo, pattern, &args.source);
+        match versioner.last_version() {
+            Some(v) => v.tag,
+            None => {
+                match args.format {
+                    OutputFormat::Json => println!("null"),
+                    OutputFormat::Text => println!("No version found"),
+                }
+                return Ok(());
+            }
+        }
+    };
+
+    let commits = gitutils::commits_since_tag_with_info(&repo, &from_tag).unwrap_or_default();
+
+    let mut breaking: Vec<ChangelogEntry> = Vec::new();
+    let mut features: Vec<ChangelogEntry> = Vec::new();
+    let mut fixes: Vec<ChangelogEntry> = Vec::new();
+    let mut other: Vec<ChangelogEntry> = Vec::new();
+
+    for commit in &commits {
+        let cc = parse_conventional_commit(&commit.message);
+        let entry = ChangelogEntry {
+            subject: cc.subject.clone(),
+            hash: commit.short_id.clone(),
+        };
+        if cc.breaking {
+            breaking.push(entry);
+        } else if cc.type_ == "feat" {
+            features.push(entry);
+        } else if cc.type_ == "fix" {
+            fixes.push(entry);
+        } else {
+            other.push(entry);
+        }
+    }
+
+    let content = match args.format {
+        OutputFormat::Json => format_changelog_json(&from_tag, &breaking, &features, &fixes, &other),
+        OutputFormat::Text => format_changelog_text(&from_tag, &breaking, &features, &fixes, &other),
+    };
+
+    if let Some(ref output_path) = args.output {
+        std::fs::write(output_path, &content)?;
+    } else {
+        print!("{}", content);
+    }
+
+    Ok(())
+}
+
+struct ChangelogEntry {
+    subject: String,
+    hash: String,
+}
+
+struct ParsedCommit {
+    type_: String,
+    subject: String,
+    breaking: bool,
+}
+
+fn parse_conventional_commit(message: &str) -> ParsedCommit {
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"(?m)^([a-z]+)(\([^)]+\))?(!)?\s*:\s*(.+)$").unwrap()
+    });
+
+    let first_line = message.lines().next().unwrap_or("").trim();
+    let has_breaking_footer =
+        message.contains("BREAKING CHANGE:") || message.contains("BREAKING-CHANGE:");
+
+    if let Some(caps) = re.captures(first_line) {
+        let type_ = caps.get(1).map_or("", |m| m.as_str()).to_string();
+        let breaking_bang = caps.get(3).is_some();
+        let subject = caps.get(4).map_or("", |m| m.as_str()).to_string();
+        ParsedCommit {
+            type_,
+            subject,
+            breaking: breaking_bang || has_breaking_footer,
+        }
+    } else {
+        ParsedCommit {
+            type_: String::new(),
+            subject: first_line.to_string(),
+            breaking: has_breaking_footer,
+        }
+    }
+}
+
+fn format_changelog_text(
+    from: &str,
+    breaking: &[ChangelogEntry],
+    features: &[ChangelogEntry],
+    fixes: &[ChangelogEntry],
+    other: &[ChangelogEntry],
+) -> String {
+    let mut out = format!("## Changelog since {}\n", from);
+
+    if !breaking.is_empty() {
+        out.push_str("\n### Breaking Changes\n");
+        for e in breaking {
+            out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
+        }
+    }
+    if !features.is_empty() {
+        out.push_str("\n### Features\n");
+        for e in features {
+            out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
+        }
+    }
+    if !fixes.is_empty() {
+        out.push_str("\n### Bug Fixes\n");
+        for e in fixes {
+            out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
+        }
+    }
+    if !other.is_empty() {
+        out.push_str("\n### Other Changes\n");
+        for e in other {
+            out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
+        }
+    }
+
+    out
+}
+
+fn format_changelog_json(
+    from: &str,
+    breaking: &[ChangelogEntry],
+    features: &[ChangelogEntry],
+    fixes: &[ChangelogEntry],
+    other: &[ChangelogEntry],
+) -> String {
+    fn entries_to_json(entries: &[ChangelogEntry]) -> String {
+        let items: Vec<String> = entries
+            .iter()
+            .map(|e| {
+                format!(
+                    "{{\"subject\":{},\"hash\":\"{}\"}}",
+                    serde_json::Value::String(e.subject.clone()),
+                    e.hash
+                )
+            })
+            .collect();
+        format!("[{}]", items.join(","))
+    }
+
+    format!(
+        "{{\"from\":\"{}\",\"breaking_changes\":{},\"features\":{},\"fixes\":{},\"other\":{}}}",
+        from,
+        entries_to_json(breaking),
+        entries_to_json(features),
+        entries_to_json(fixes),
+        entries_to_json(other),
+    )
 }
 
 fn try_fetch_from_origin(repo: &git2::Repository) {
@@ -183,13 +388,10 @@ fn try_fetch_from_origin(repo: &git2::Repository) {
 
 const SEP: &str = "─";
 
-/// Formats a Unix timestamp as `YYYY-MM-DD`.
 fn format_date(ts: i64) -> String {
-    // Days since Unix epoch.
     let secs = ts.max(0) as u64;
     let days_since_epoch = secs / 86400;
 
-    // Gregorian calendar calculation (no external dep needed for dates after 1970).
     let mut remaining = days_since_epoch;
     let mut year = 1970u32;
     loop {
@@ -222,11 +424,6 @@ fn is_leap(year: u32) -> bool {
     (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
 }
 
-/// Returns the rule set to use for `--auto`.
-///
-/// If `raw_rules` is empty the built-in conventional-commit defaults are used.
-/// Otherwise each entry is parsed as `<level>:<regex>` and any parse error is
-/// surfaced immediately so the user gets a clear message before any git I/O.
 fn build_rules(raw_rules: &[String]) -> Result<Vec<BumpRule>, FlophaError> {
     if raw_rules.is_empty() {
         return Ok(versioning::conventional_bump_rules());
@@ -305,6 +502,7 @@ mod tests {
             pattern: Some("flopha@{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
             checkout: false,
+            format: OutputFormat::Text,
         };
 
         let result = last_version(td.path(), &args).unwrap();
@@ -326,6 +524,7 @@ mod tests {
             pattern: Some("flopha@{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
             checkout: false,
+            format: OutputFormat::Text,
         };
         let result = last_version(td.path(), &args).unwrap();
 
@@ -353,6 +552,7 @@ mod tests {
             pattern: Some("flopha@{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
             checkout: true,
+            format: OutputFormat::Text,
         };
         last_version(td.path(), &args).unwrap();
 
@@ -375,6 +575,7 @@ mod tests {
             pattern: Some("release-{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
             checkout: false,
+            format: OutputFormat::Text,
         };
 
         let result = last_version(td.path(), &args).unwrap();
@@ -406,6 +607,7 @@ mod tests {
             pattern: Some("release/{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Branch,
             checkout: false,
+            format: OutputFormat::Text,
         };
 
         let result = last_version(td.path(), &args).unwrap();
@@ -433,6 +635,7 @@ mod tests {
             pattern: Some("release/{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Branch,
             checkout: false,
+            format: OutputFormat::Text,
         };
 
         let result = last_version(td.path(), &args).unwrap();
@@ -459,6 +662,7 @@ mod tests {
             pattern: Some("release/{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Branch,
             checkout: true,
+            format: OutputFormat::Text,
         };
         last_version(td.path(), &args).unwrap();
 
@@ -500,6 +704,7 @@ mod tests {
             pre: None,
             source: VersionSourceName::Tag,
             create: false,
+            format: OutputFormat::Text,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -532,6 +737,7 @@ mod tests {
             pre: None,
             source: VersionSourceName::Tag,
             create: true,
+            format: OutputFormat::Text,
         };
         next_version(td.path(), &args).unwrap();
 
@@ -569,6 +775,7 @@ mod tests {
             pre: None,
             source: VersionSourceName::Branch,
             create: false,
+            format: OutputFormat::Text,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -593,6 +800,7 @@ mod tests {
             pre: None,
             source: VersionSourceName::Branch,
             create: false,
+            format: OutputFormat::Text,
         };
 
         let result = next_version(td.path(), &args).unwrap();
@@ -620,6 +828,7 @@ mod tests {
             pre: None,
             source: VersionSourceName::Branch,
             create: true,
+            format: OutputFormat::Text,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -652,6 +861,7 @@ mod tests {
             pre: None,
             source: VersionSourceName::Tag,
             create: false,
+            format: OutputFormat::Text,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -678,6 +888,7 @@ mod tests {
             pre: Some("alpha".to_string()),
             source: VersionSourceName::Tag,
             create: false,
+            format: OutputFormat::Text,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -689,7 +900,6 @@ mod tests {
         let (td, repo) = testutils::init_repo();
         let (_remote_td, mut remote) = testutils::init_remote(&repo);
 
-        // v1.0.1-alpha.1 already exists; next should be alpha.2
         let tags = vec!["v1.0.0", "v1.0.1-alpha.1"];
         for tag in tags {
             create_new_remote_tag(&repo, &mut remote, tag, false);
@@ -705,6 +915,7 @@ mod tests {
             pre: Some("alpha".to_string()),
             source: VersionSourceName::Tag,
             create: false,
+            format: OutputFormat::Text,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -721,8 +932,6 @@ mod tests {
             create_new_remote_tag(&repo, &mut remote, tag, false);
         }
         gitutils::checkout_tag(&repo, "v1.0.0").unwrap();
-        // This commit would be "minor" under conventional commits, but with a
-        // custom rule only "BUMP_MAJOR:" triggers major and nothing else matches minor.
         gitutils::commit(&repo, "feat: add thing").unwrap();
 
         let args = NextVersionArgs {
@@ -733,11 +942,34 @@ mod tests {
             pre: None,
             source: VersionSourceName::Tag,
             create: false,
+            format: OutputFormat::Text,
         };
         let result = next_version(td.path(), &args).unwrap();
 
-        // "feat:" doesn't match any custom rule → falls through to patch
         assert_eq!(result, Some("v1.0.1".to_string()));
+    }
+
+    #[test]
+    fn test_changelog_categorizes_conventional_commits() {
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, mut remote) = testutils::init_remote(&repo);
+
+        create_new_remote_tag(&repo, &mut remote, "v1.0.0", false);
+        gitutils::checkout_tag(&repo, "v1.0.0").unwrap();
+        gitutils::commit(&repo, "feat: add search").unwrap();
+        gitutils::commit(&repo, "fix: crash on empty input").unwrap();
+        gitutils::commit(&repo, "chore: update deps").unwrap();
+
+        let args = ChangelogArgs {
+            from: Some("v1.0.0".to_string()),
+            pattern: Some("v{major}.{minor}.{patch}".to_string()),
+            source: VersionSourceName::Tag,
+            output: None,
+            format: OutputFormat::Text,
+        };
+
+        // Should not error and should produce non-empty output.
+        changelog(td.path(), &args).unwrap();
     }
 
     fn create_new_remote_tag(

--- a/src/service.rs
+++ b/src/service.rs
@@ -265,10 +265,18 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
         }
     }
 
-    let title = args.title.replace("{from}", &from_tag);
+    let title = match &args.title {
+        Some(t) => t
+            .replace("{from}", &from_tag)
+            .replace("{to}", args.to.as_deref().unwrap_or("")),
+        None => match &args.to {
+            Some(to) => format!("Changes in {}", to),
+            None => format!("Changelog since {}", from_tag),
+        },
+    };
 
     let content = match args.format {
-        OutputFormat::Json => format_changelog_json(&title, &from_tag, &groups),
+        OutputFormat::Json => format_changelog_json(&title, &from_tag, args.to.as_deref(), &groups),
         OutputFormat::Text => format_changelog_text(&title, &groups),
     };
 
@@ -342,7 +350,7 @@ fn format_changelog_text(title: &str, groups: &[(String, Vec<ChangelogEntry>)]) 
     out
 }
 
-fn format_changelog_json(title: &str, from: &str, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
+fn format_changelog_json(title: &str, from: &str, to: Option<&str>, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
     let groups_val: Vec<serde_json::Value> = groups
         .iter()
         .map(|(group_title, entries)| {
@@ -353,7 +361,11 @@ fn format_changelog_json(title: &str, from: &str, groups: &[(String, Vec<Changel
             serde_json::json!({"title": group_title, "entries": entries_val})
         })
         .collect();
-    serde_json::json!({"title": title, "from": from, "groups": groups_val}).to_string() + "\n"
+    let mut obj = serde_json::json!({"title": title, "from": from, "groups": groups_val});
+    if let Some(to) = to {
+        obj["to"] = serde_json::json!(to);
+    }
+    obj.to_string() + "\n"
 }
 
 fn try_fetch_from_origin(repo: &git2::Repository) {
@@ -947,7 +959,8 @@ mod tests {
             source: VersionSourceName::Tag,
             group: vec![],
             other: None,
-            title: "Changelog since {from}".to_string(),
+            title: None,
+            to: None,
             overwrite: false,
             output: None,
             format: OutputFormat::Text,
@@ -973,7 +986,8 @@ mod tests {
             source: VersionSourceName::Tag,
             group: vec!["Breaking:BUMP_MAJOR:".to_string(), "Additions:^ADD:".to_string()],
             other: None,
-            title: "Changelog since {from}".to_string(),
+            title: None,
+            to: None,
             overwrite: false,
             output: None,
             format: OutputFormat::Text,
@@ -1017,11 +1031,12 @@ mod tests {
                 ChangelogEntry { subject: "fix crash".to_string(), hash: "def5678".to_string() },
             ]),
         ];
-        let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", &groups);
+        let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", None, &groups);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
 
         assert_eq!(v["title"], "Changelog since v1.0.0");
         assert_eq!(v["from"], "v1.0.0");
+        assert!(v.get("to").is_none() || v["to"].is_null());
         assert_eq!(v["groups"].as_array().unwrap().len(), 2);
         assert_eq!(v["groups"][0]["title"], "Features");
         assert_eq!(v["groups"][0]["entries"][0]["subject"], "add search");
@@ -1039,22 +1054,39 @@ mod tests {
                 },
             ]),
         ];
-        let json = format_changelog_json(r#"Release v1.0.0"edge""#, r#"v1.0.0"edge"#, &groups);
+        let json = format_changelog_json(r#"Release v1.0.0"edge""#, r#"v1.0.0"edge"#, Some(r#"v1.0.0"edge""#), &groups);
 
         // Must parse without error despite embedded quotes and backslashes.
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON with special chars");
         assert_eq!(v["title"], r#"Release v1.0.0"edge""#);
         assert_eq!(v["from"], r#"v1.0.0"edge"#);
+        assert_eq!(v["to"], r#"v1.0.0"edge""#);
         assert_eq!(v["groups"][0]["title"], r#"Group "A""#);
         assert_eq!(v["groups"][0]["entries"][0]["subject"], r#"feat: support "quoted" args and backslash \"#);
     }
 
     #[test]
     fn test_changelog_json_empty_groups() {
-        let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", &[]);
+        let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", None, &[]);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["from"], "v1.0.0");
+        assert!(v.get("to").is_none() || v["to"].is_null());
         assert!(v["groups"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_changelog_json_with_to_field() {
+        let groups = vec![
+            ("Features".to_string(), vec![
+                ChangelogEntry { subject: "add search".to_string(), hash: "abc1234".to_string() },
+            ]),
+        ];
+        let json = format_changelog_json("Changes in v1.1.0", "v1.0.0", Some("v1.1.0"), &groups);
+        let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+        assert_eq!(v["title"], "Changes in v1.1.0");
+        assert_eq!(v["from"], "v1.0.0");
+        assert_eq!(v["to"], "v1.1.0");
+        assert_eq!(v["groups"][0]["title"], "Features");
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -265,13 +265,20 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
         }
     }
 
+    let title = args.title.replace("{from}", &from_tag);
+
     let content = match args.format {
-        OutputFormat::Json => format_changelog_json(&from_tag, &groups),
-        OutputFormat::Text => format_changelog_text(&from_tag, &groups),
+        OutputFormat::Json => format_changelog_json(&title, &from_tag, &groups),
+        OutputFormat::Text => format_changelog_text(&title, &groups),
     };
 
     if let Some(ref output_path) = args.output {
-        std::fs::write(output_path, &content)?;
+        if args.prepend && std::path::Path::new(output_path).exists() {
+            let existing = std::fs::read_to_string(output_path)?;
+            std::fs::write(output_path, format!("{}\n{}", content, existing))?;
+        } else {
+            std::fs::write(output_path, &content)?;
+        }
     } else {
         print!("{}", content);
     }
@@ -324,8 +331,8 @@ fn parse_group_rule(s: &str) -> Result<GroupRule, FlophaError> {
     })
 }
 
-fn format_changelog_text(from: &str, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
-    let mut out = format!("## Changelog since {}\n", from);
+fn format_changelog_text(title: &str, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
+    let mut out = format!("## {}\n", title);
     for (title, entries) in groups {
         out.push_str(&format!("\n### {}\n", title));
         for e in entries {
@@ -335,18 +342,18 @@ fn format_changelog_text(from: &str, groups: &[(String, Vec<ChangelogEntry>)]) -
     out
 }
 
-fn format_changelog_json(from: &str, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
+fn format_changelog_json(title: &str, from: &str, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
     let groups_val: Vec<serde_json::Value> = groups
         .iter()
-        .map(|(title, entries)| {
+        .map(|(group_title, entries)| {
             let entries_val: Vec<serde_json::Value> = entries
                 .iter()
                 .map(|e| serde_json::json!({"subject": e.subject, "hash": e.hash}))
                 .collect();
-            serde_json::json!({"title": title, "entries": entries_val})
+            serde_json::json!({"title": group_title, "entries": entries_val})
         })
         .collect();
-    serde_json::json!({"from": from, "groups": groups_val}).to_string()
+    serde_json::json!({"title": title, "from": from, "groups": groups_val}).to_string()
 }
 
 fn try_fetch_from_origin(repo: &git2::Repository) {
@@ -940,6 +947,8 @@ mod tests {
             source: VersionSourceName::Tag,
             group: vec![],
             other: None,
+            title: "Changelog since {from}".to_string(),
+            prepend: false,
             output: None,
             format: OutputFormat::Text,
         };
@@ -964,6 +973,8 @@ mod tests {
             source: VersionSourceName::Tag,
             group: vec!["Breaking:BUMP_MAJOR:".to_string(), "Additions:^ADD:".to_string()],
             other: None,
+            title: "Changelog since {from}".to_string(),
+            prepend: false,
             output: None,
             format: OutputFormat::Text,
         };
@@ -1006,9 +1017,10 @@ mod tests {
                 ChangelogEntry { subject: "fix crash".to_string(), hash: "def5678".to_string() },
             ]),
         ];
-        let json = format_changelog_json("v1.0.0", &groups);
+        let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", &groups);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
 
+        assert_eq!(v["title"], "Changelog since v1.0.0");
         assert_eq!(v["from"], "v1.0.0");
         assert_eq!(v["groups"].as_array().unwrap().len(), 2);
         assert_eq!(v["groups"][0]["title"], "Features");
@@ -1027,10 +1039,11 @@ mod tests {
                 },
             ]),
         ];
-        let json = format_changelog_json(r#"v1.0.0"edge"#, &groups);
+        let json = format_changelog_json(r#"Release v1.0.0"edge""#, r#"v1.0.0"edge"#, &groups);
 
         // Must parse without error despite embedded quotes and backslashes.
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON with special chars");
+        assert_eq!(v["title"], r#"Release v1.0.0"edge""#);
         assert_eq!(v["from"], r#"v1.0.0"edge"#);
         assert_eq!(v["groups"][0]["title"], r#"Group "A""#);
         assert_eq!(v["groups"][0]["entries"][0]["subject"], r#"feat: support "quoted" args and backslash \"#);
@@ -1038,7 +1051,7 @@ mod tests {
 
     #[test]
     fn test_changelog_json_empty_groups() {
-        let json = format_changelog_json("v1.0.0", &[]);
+        let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", &[]);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["from"], "v1.0.0");
         assert!(v["groups"].as_array().unwrap().is_empty());

--- a/src/service.rs
+++ b/src/service.rs
@@ -287,7 +287,11 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     if let Some(ref output_path) = args.output {
         if !args.overwrite && std::path::Path::new(output_path).exists() {
             let existing = std::fs::read_to_string(output_path)?;
-            std::fs::write(output_path, format!("{}\n{}", content, existing))?;
+            // Write to a sibling temp file then rename so the original is never
+            // left empty if the process is interrupted between the two operations.
+            let tmp_path = format!("{}.flopha.tmp", output_path);
+            std::fs::write(&tmp_path, format!("{}\n{}", content, existing))?;
+            std::fs::rename(&tmp_path, output_path)?;
         } else {
             std::fs::write(output_path, &content)?;
         }

--- a/src/service.rs
+++ b/src/service.rs
@@ -228,46 +228,46 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
         }
     };
 
-    let section_rules = build_section_rules(&args.group)?;
+    let group_rules = build_group_rules(&args.group)?;
     let commits = gitutils::commits_since_tag_with_info(&repo, &from_tag)?;
 
     // Pre-build ordered section labels from the rules (deduplicated).
-    let mut section_order: Vec<String> = Vec::new();
-    for rule in &section_rules {
-        if !section_order.contains(&rule.title) {
-            section_order.push(rule.title.clone());
+    let mut group_order: Vec<String> = Vec::new();
+    for rule in &group_rules {
+        if !group_order.contains(&rule.title) {
+            group_order.push(rule.title.clone());
         }
     }
-    let mut section_entries: HashMap<String, Vec<ChangelogEntry>> = HashMap::new();
+    let mut group_entries: HashMap<String, Vec<ChangelogEntry>> = HashMap::new();
     let mut other: Vec<ChangelogEntry> = Vec::new();
 
     for commit in &commits {
         let subject = commit.message.lines().next().unwrap_or("").trim().to_string();
         let entry = ChangelogEntry { subject, hash: commit.short_id.clone() };
-        match section_rules.iter().find(|r| r.pattern.is_match(&commit.message)) {
-            Some(rule) => section_entries.entry(rule.title.clone()).or_default().push(entry),
+        match group_rules.iter().find(|r| r.pattern.is_match(&commit.message)) {
+            Some(rule) => group_entries.entry(rule.title.clone()).or_default().push(entry),
             None => other.push(entry),
         }
     }
 
     // Collect in rule-defined order, skipping empty sections.
-    let mut sections: Vec<(String, Vec<ChangelogEntry>)> = section_order
+    let mut groups: Vec<(String, Vec<ChangelogEntry>)> = group_order
         .into_iter()
         .filter_map(|title| {
-            section_entries.remove(&title).filter(|e| !e.is_empty()).map(|e| (title, e))
+            group_entries.remove(&title).filter(|e| !e.is_empty()).map(|e| (title, e))
         })
         .collect();
     if !other.is_empty() {
         match args.other.as_deref() {
             Some("") => {}  // suppress unmatched commits
-            Some(title) => sections.push((title.to_string(), other)),
-            None => sections.push(("Other Changes".to_string(), other)),
+            Some(title) => groups.push((title.to_string(), other)),
+            None => groups.push(("Other Changes".to_string(), other)),
         }
     }
 
     let content = match args.format {
-        OutputFormat::Json => format_changelog_json(&from_tag, &sections),
-        OutputFormat::Text => format_changelog_text(&from_tag, &sections),
+        OutputFormat::Json => format_changelog_json(&from_tag, &groups),
+        OutputFormat::Text => format_changelog_text(&from_tag, &groups),
     };
 
     if let Some(ref output_path) = args.output {
@@ -284,12 +284,12 @@ struct ChangelogEntry {
     hash: String,
 }
 
-struct SectionRule {
+struct GroupRule {
     title: String,
     pattern: regex::Regex,
 }
 
-impl SectionRule {
+impl GroupRule {
     fn new(title: &str, pattern: &str) -> Result<Self, regex::Error> {
         Ok(Self {
             title: title.to_string(),
@@ -298,35 +298,35 @@ impl SectionRule {
     }
 }
 
-fn default_changelog_sections() -> Vec<SectionRule> {
+fn default_changelog_groups() -> Vec<GroupRule> {
     vec![
-        SectionRule::new("Breaking Changes", r"BREAKING[- ]CHANGE|(?m)^[a-z]+(\([^)]+\))?!:").unwrap(),
-        SectionRule::new("Features", r"(?m)^feat(\([^)]+\))?:").unwrap(),
-        SectionRule::new("Bug Fixes", r"(?m)^fix(\([^)]+\))?:").unwrap(),
+        GroupRule::new("Breaking Changes", r"BREAKING[- ]CHANGE|(?m)^[a-z]+(\([^)]+\))?!:").unwrap(),
+        GroupRule::new("Features", r"(?m)^feat(\([^)]+\))?:").unwrap(),
+        GroupRule::new("Bug Fixes", r"(?m)^fix(\([^)]+\))?:").unwrap(),
     ]
 }
 
-fn build_section_rules(raw: &[String]) -> Result<Vec<SectionRule>, FlophaError> {
+fn build_group_rules(raw: &[String]) -> Result<Vec<GroupRule>, FlophaError> {
     if raw.is_empty() {
-        return Ok(default_changelog_sections());
+        return Ok(default_changelog_groups());
     }
-    raw.iter().map(|s| parse_section_rule(s)).collect()
+    raw.iter().map(|s| parse_group_rule(s)).collect()
 }
 
-fn parse_section_rule(s: &str) -> Result<SectionRule, FlophaError> {
+fn parse_group_rule(s: &str) -> Result<GroupRule, FlophaError> {
     let (title, pattern) = s.split_once(':').ok_or_else(|| FlophaError::InvalidRule {
         input: s.to_string(),
         reason: "expected format 'TITLE:PATTERN'".to_string(),
     })?;
-    SectionRule::new(title, pattern).map_err(|e| FlophaError::InvalidRule {
+    GroupRule::new(title, pattern).map_err(|e| FlophaError::InvalidRule {
         input: s.to_string(),
         reason: format!("invalid regex: {}", e),
     })
 }
 
-fn format_changelog_text(from: &str, sections: &[(String, Vec<ChangelogEntry>)]) -> String {
+fn format_changelog_text(from: &str, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
     let mut out = format!("## Changelog since {}\n", from);
-    for (title, entries) in sections {
+    for (title, entries) in groups {
         out.push_str(&format!("\n### {}\n", title));
         for e in entries {
             out.push_str(&format!("- {} ({})\n", e.subject, e.hash));
@@ -335,8 +335,8 @@ fn format_changelog_text(from: &str, sections: &[(String, Vec<ChangelogEntry>)])
     out
 }
 
-fn format_changelog_json(from: &str, sections: &[(String, Vec<ChangelogEntry>)]) -> String {
-    let sections_val: Vec<serde_json::Value> = sections
+fn format_changelog_json(from: &str, groups: &[(String, Vec<ChangelogEntry>)]) -> String {
+    let groups_val: Vec<serde_json::Value> = groups
         .iter()
         .map(|(title, entries)| {
             let entries_val: Vec<serde_json::Value> = entries
@@ -346,7 +346,7 @@ fn format_changelog_json(from: &str, sections: &[(String, Vec<ChangelogEntry>)])
             serde_json::json!({"title": title, "entries": entries_val})
         })
         .collect();
-    serde_json::json!({"from": from, "sections": sections_val}).to_string()
+    serde_json::json!({"from": from, "groups": groups_val}).to_string()
 }
 
 fn try_fetch_from_origin(repo: &git2::Repository) {
@@ -998,7 +998,7 @@ mod tests {
 
     #[test]
     fn test_changelog_json_structure() {
-        let sections = vec![
+        let groups = vec![
             ("Features".to_string(), vec![
                 ChangelogEntry { subject: "add search".to_string(), hash: "abc1234".to_string() },
             ]),
@@ -1006,42 +1006,42 @@ mod tests {
                 ChangelogEntry { subject: "fix crash".to_string(), hash: "def5678".to_string() },
             ]),
         ];
-        let json = format_changelog_json("v1.0.0", &sections);
+        let json = format_changelog_json("v1.0.0", &groups);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
 
         assert_eq!(v["from"], "v1.0.0");
-        assert_eq!(v["sections"].as_array().unwrap().len(), 2);
-        assert_eq!(v["sections"][0]["title"], "Features");
-        assert_eq!(v["sections"][0]["entries"][0]["subject"], "add search");
-        assert_eq!(v["sections"][0]["entries"][0]["hash"], "abc1234");
-        assert_eq!(v["sections"][1]["title"], "Bug Fixes");
+        assert_eq!(v["groups"].as_array().unwrap().len(), 2);
+        assert_eq!(v["groups"][0]["title"], "Features");
+        assert_eq!(v["groups"][0]["entries"][0]["subject"], "add search");
+        assert_eq!(v["groups"][0]["entries"][0]["hash"], "abc1234");
+        assert_eq!(v["groups"][1]["title"], "Bug Fixes");
     }
 
     #[test]
     fn test_changelog_json_escapes_special_chars() {
-        let sections = vec![
-            (r#"Section "A""#.to_string(), vec![
+        let groups = vec![
+            (r#"Group "A""#.to_string(), vec![
                 ChangelogEntry {
                     subject: r#"feat: support "quoted" args and backslash \"#.to_string(),
                     hash: "abc1234".to_string(),
                 },
             ]),
         ];
-        let json = format_changelog_json(r#"v1.0.0"edge"#, &sections);
+        let json = format_changelog_json(r#"v1.0.0"edge"#, &groups);
 
         // Must parse without error despite embedded quotes and backslashes.
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON with special chars");
         assert_eq!(v["from"], r#"v1.0.0"edge"#);
-        assert_eq!(v["sections"][0]["title"], r#"Section "A""#);
-        assert_eq!(v["sections"][0]["entries"][0]["subject"], r#"feat: support "quoted" args and backslash \"#);
+        assert_eq!(v["groups"][0]["title"], r#"Group "A""#);
+        assert_eq!(v["groups"][0]["entries"][0]["subject"], r#"feat: support "quoted" args and backslash \"#);
     }
 
     #[test]
-    fn test_changelog_json_empty_sections() {
+    fn test_changelog_json_empty_groups() {
         let json = format_changelog_json("v1.0.0", &[]);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["from"], "v1.0.0");
-        assert!(v["sections"].as_array().unwrap().is_empty());
+        assert!(v["groups"].as_array().unwrap().is_empty());
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -18,7 +18,7 @@ pub fn last_version(path: &Path, args: &LastVersionArgs) -> Result<Option<String
     let versioner = versioner_factory(&repo, pattern, &args.source);
     if let Some(version) = versioner.last_version() {
         match args.format {
-            OutputFormat::Json => println!("{{\"version\":\"{}\"}}", version.tag),
+            OutputFormat::Json => println!("{}", serde_json::json!({"version": version.tag})),
             OutputFormat::Text => println!("{}", version.tag),
         }
 
@@ -82,7 +82,7 @@ pub fn next_version(path: &Path, args: &NextVersionArgs) -> Result<Option<String
     };
 
     match args.format {
-        OutputFormat::Json => println!("{{\"version\":\"{}\"}}", final_tag),
+        OutputFormat::Json => println!("{}", serde_json::json!({"version": final_tag})),
         OutputFormat::Text => println!("{}", final_tag),
     }
 
@@ -166,22 +166,19 @@ pub fn log_versions(path: &Path, args: &LogArgs) -> Result<(), FlophaError> {
 
     match args.format {
         OutputFormat::Json => {
-            let entries: Vec<String> = rows
+            let entries: Vec<serde_json::Value> = rows
                 .iter()
                 .enumerate()
                 .map(|(i, (tag, date, count))| {
-                    let commits_val = if i + 1 < rows.len() {
-                        count.to_string()
+                    let commits = if i + 1 < rows.len() {
+                        serde_json::Value::Number((*count).into())
                     } else {
-                        "null".to_string()
+                        serde_json::Value::Null
                     };
-                    format!(
-                        "{{\"version\":\"{}\",\"date\":\"{}\",\"commits\":{}}}",
-                        tag, date, commits_val
-                    )
+                    serde_json::json!({"version": tag, "date": date, "commits": commits})
                 })
                 .collect();
-            println!("[{}]", entries.join(","));
+            println!("{}", serde_json::Value::Array(entries));
         }
         OutputFormat::Text => {
             let tag_width = rows.iter().map(|(t, _, _)| t.len()).max().unwrap_or(0);
@@ -232,7 +229,7 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     };
 
     let section_rules = build_section_rules(&args.group)?;
-    let commits = gitutils::commits_since_tag_with_info(&repo, &from_tag).unwrap_or_default();
+    let commits = gitutils::commits_since_tag_with_info(&repo, &from_tag)?;
 
     // Pre-build ordered section labels from the rules (deduplicated).
     let mut section_order: Vec<String> = Vec::new();
@@ -339,32 +336,17 @@ fn format_changelog_text(from: &str, sections: &[(String, Vec<ChangelogEntry>)])
 }
 
 fn format_changelog_json(from: &str, sections: &[(String, Vec<ChangelogEntry>)]) -> String {
-    fn entries_json(entries: &[ChangelogEntry]) -> String {
-        let items: Vec<String> = entries
-            .iter()
-            .map(|e| format!(
-                "{{\"subject\":{},\"hash\":\"{}\"}}",
-                serde_json::Value::String(e.subject.clone()),
-                e.hash
-            ))
-            .collect();
-        format!("[{}]", items.join(","))
-    }
-
-    let sections_json: Vec<String> = sections
+    let sections_val: Vec<serde_json::Value> = sections
         .iter()
-        .map(|(title, entries)| format!(
-            "{{\"title\":{},\"entries\":{}}}",
-            serde_json::Value::String(title.clone()),
-            entries_json(entries)
-        ))
+        .map(|(title, entries)| {
+            let entries_val: Vec<serde_json::Value> = entries
+                .iter()
+                .map(|e| serde_json::json!({"subject": e.subject, "hash": e.hash}))
+                .collect();
+            serde_json::json!({"title": title, "entries": entries_val})
+        })
         .collect();
-
-    format!(
-        "{{\"from\":\"{}\",\"sections\":[{}]}}",
-        from,
-        sections_json.join(",")
-    )
+    serde_json::json!({"from": from, "sections": sections_val}).to_string()
 }
 
 fn try_fetch_from_origin(repo: &git2::Repository) {

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -34,6 +34,40 @@ pub fn conventional_bump_rules() -> Vec<BumpRule> {
     ]
 }
 
+/// Default changelog rules — extends [`conventional_bump_rules`] with `fix:` → Patch
+/// so that bug-fix commits land in "Bug Fixes" rather than "Other Changes".
+pub fn conventional_changelog_rules() -> Vec<BumpRule> {
+    vec![
+        BumpRule::new(r"BREAKING[- ]CHANGE", Increment::Major).unwrap(),
+        BumpRule::new(r"(?m)^[a-z]+(\([^)]+\))?!:", Increment::Major).unwrap(),
+        BumpRule::new(r"(?m)^feat(\([^)]+\))?:", Increment::Minor).unwrap(),
+        BumpRule::new(r"(?m)^fix(\([^)]+\))?:", Increment::Patch).unwrap(),
+    ]
+}
+
+/// Classifies a single commit message against `rules`.
+///
+/// Returns `Some(Major)` on the first major match, `Some(Minor)` for the highest
+/// minor, `Some(Patch)` if only patch rules fire, and `None` when nothing matches
+/// (the commit falls into "Other Changes" in a changelog).
+pub fn classify_commit(message: &str, rules: &[BumpRule]) -> Option<Increment> {
+    let mut best: Option<Increment> = None;
+    for rule in rules {
+        if rule.pattern.is_match(message) {
+            match rule.increment {
+                Increment::Major => return Some(Increment::Major),
+                Increment::Minor => best = Some(Increment::Minor),
+                Increment::Patch => {
+                    if best.is_none() {
+                        best = Some(Increment::Patch);
+                    }
+                }
+            }
+        }
+    }
+    best
+}
+
 /// Infers the highest-priority [`Increment`] from `messages` using `rules`.
 ///
 /// Every rule is tested against every message independently; the highest-priority

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -34,40 +34,6 @@ pub fn conventional_bump_rules() -> Vec<BumpRule> {
     ]
 }
 
-/// Default changelog rules — extends [`conventional_bump_rules`] with `fix:` → Patch
-/// so that bug-fix commits land in "Bug Fixes" rather than "Other Changes".
-pub fn conventional_changelog_rules() -> Vec<BumpRule> {
-    vec![
-        BumpRule::new(r"BREAKING[- ]CHANGE", Increment::Major).unwrap(),
-        BumpRule::new(r"(?m)^[a-z]+(\([^)]+\))?!:", Increment::Major).unwrap(),
-        BumpRule::new(r"(?m)^feat(\([^)]+\))?:", Increment::Minor).unwrap(),
-        BumpRule::new(r"(?m)^fix(\([^)]+\))?:", Increment::Patch).unwrap(),
-    ]
-}
-
-/// Classifies a single commit message against `rules`.
-///
-/// Returns `Some(Major)` on the first major match, `Some(Minor)` for the highest
-/// minor, `Some(Patch)` if only patch rules fire, and `None` when nothing matches
-/// (the commit falls into "Other Changes" in a changelog).
-pub fn classify_commit(message: &str, rules: &[BumpRule]) -> Option<Increment> {
-    let mut best: Option<Increment> = None;
-    for rule in rules {
-        if rule.pattern.is_match(message) {
-            match rule.increment {
-                Increment::Major => return Some(Increment::Major),
-                Increment::Minor => best = Some(Increment::Minor),
-                Increment::Patch => {
-                    if best.is_none() {
-                        best = Some(Increment::Patch);
-                    }
-                }
-            }
-        }
-    }
-    best
-}
-
 /// Infers the highest-priority [`Increment`] from `messages` using `rules`.
 ///
 /// Every rule is tested against every message independently; the highest-priority

--- a/website/docs/command-reference.mdx
+++ b/website/docs/command-reference.mdx
@@ -10,7 +10,7 @@ title: Command Reference
 Print the latest matching version.
 
 ```bash
-flopha last-version [--pattern <pattern>] [--source <tag|branch>] [--checkout]
+flopha last-version [--pattern <pattern>] [--source <tag|branch>] [--checkout] [--format <text|json>]
 ```
 
 Options:
@@ -18,6 +18,7 @@ Options:
 - `--pattern`, `-p`: Match a custom version format.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--checkout`: Check out the resolved version after printing it.
+- `--format`, `-f`: Output format — `text` (default) or `json`.
 
 ## `flopha next-version`
 
@@ -31,7 +32,8 @@ flopha next-version \
   [--pre <channel>] \
   [--pattern <pattern>] \
   [--source <tag|branch>] \
-  [--create]
+  [--create] \
+  [--format <text|json>]
 ```
 
 Options:
@@ -43,13 +45,14 @@ Options:
 - `--pattern`, `-p`: Match and generate a custom version format.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--create`: Create the new tag or branch after printing it.
+- `--format`, `-f`: Output format — `text` (default) or `json`.
 
 ## `flopha log`
 
 Show matching versions newest first.
 
 ```bash
-flopha log [--pattern <pattern>] [--source <tag|branch>] [--limit <number>]
+flopha log [--pattern <pattern>] [--source <tag|branch>] [--limit <number>] [--format <text|json>]
 ```
 
 Options:
@@ -57,6 +60,69 @@ Options:
 - `--pattern`, `-p`: Match a custom version format.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--limit`, `-n`: Limit the number of rows.
+- `--format`, `-f`: Output format — `text` (default) or `json`.
+
+## `flopha changelog`
+
+Generate a changelog from commits since the last (or a given) version.
+
+```bash
+flopha changelog \
+  [--from <tag>] \
+  [--to <version>] \
+  [--pattern <pattern>] \
+  [--source <tag|branch>] \
+  [--group <TITLE:REGEX>] \
+  [--other <title>] \
+  [--title <template>] \
+  [--output <file>] \
+  [--overwrite] \
+  [--format <text|json>]
+```
+
+Options:
+
+- `--from`: Tag to start from. Defaults to the latest matching tag.
+- `--to`: Target version label (does not need to exist as a tag yet). Exposed as `{to}` in `--title`. Useful for stamping the upcoming version before creating the tag.
+- `--pattern`, `-p`: Match a custom version format.
+- `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
+- `--group`: Custom group rule as `TITLE:REGEX`. Repeatable. When any `--group` flags are given they replace the built-in defaults entirely. Commits not matching any group are collected under the fallback group.
+- `--other`: Title for commits that match no group. Pass an empty string to suppress them entirely. Default: `"Other Changes"`.
+- `--title`: Heading template. Use `{from}` for the starting tag and `{to}` for the target version. Defaults to `"Changes in {to}"` when `--to` is given, otherwise `"Changelog since {from}"`.
+- `--output`, `-o`: Write to a file instead of stdout. By default the new content is **prepended** to any existing file content.
+- `--overwrite`: Replace the output file instead of prepending.
+- `--format`, `-f`: Output format — `text` (default, Markdown) or `json`.
+
+### Default groups
+
+When no `--group` flags are provided, commits are classified as:
+
+| Section | Matched commits |
+|---------|----------------|
+| Breaking Changes | `BREAKING CHANGE`, `BREAKING-CHANGE`, or `type!:` |
+| Features | `feat:` or `feat(scope):` |
+| Bug Fixes | `fix:` or `fix(scope):` |
+| Other Changes | Everything else |
+
+### JSON output schema
+
+```json
+{
+  "title": "Changes in v1.2.0",
+  "from": "v1.1.0",
+  "to": "v1.2.0",
+  "groups": [
+    {
+      "title": "Features",
+      "entries": [
+        { "subject": "add search command", "hash": "abc1234" }
+      ]
+    }
+  ]
+}
+```
+
+`to` is only present when `--to` was supplied. Groups with no matching commits are omitted.
 
 ## Global behavior
 

--- a/website/docs/release-workflows.mdx
+++ b/website/docs/release-workflows.mdx
@@ -51,3 +51,143 @@ flopha log --pattern "desktop@{major}.{minor}.{patch}" --limit 20
 ```
 
 The log output includes the version, the release date, and the number of commits since the previous matching version.
+
+---
+
+## Using flopha in CI
+
+All flopha commands output plain text by default and `--format json` for machine consumption, making them easy to integrate into any CI pipeline.
+
+### Minimal release pipeline (shell)
+
+```bash
+# 1. Compute the next version without creating it yet
+NEXT=$(flopha next-version --auto --format json | jq -r '.version')
+
+# 2. Generate changelog headed with the upcoming version
+flopha changelog --to "$NEXT" --output CHANGELOG.md
+
+# 3. Commit the updated changelog
+git add CHANGELOG.md
+git commit -m "chore: release $NEXT"
+
+# 4. Tag and push
+flopha next-version --auto --create
+git push origin "$NEXT"
+```
+
+`--to` stamps the target version into the changelog heading **before** the tag exists, so the commit and the tag refer to the same version string.
+
+### GitHub Actions — using the action
+
+The `sjquant/flopha` action wraps the common tag-and-release flow with a single step.
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # full history so flopha can walk commits
+
+      - name: Tag and release
+        uses: sjquant/flopha@v1
+        with:
+          auto: true
+          create-release: true
+          changelog: true       # generate changelog and use it as the release body
+```
+
+### GitHub Actions — full changelog pipeline
+
+For full control over the changelog before tagging:
+
+```yaml
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install flopha
+        run: |
+          curl -fsSL https://github.com/sjquant/flopha/releases/latest/download/install.sh | bash
+          echo "$HOME/.flopha/bin" >> $GITHUB_PATH
+
+      - name: Compute next version
+        id: version
+        run: echo "tag=$(flopha next-version --auto --format json | jq -r '.version')" >> $GITHUB_OUTPUT
+
+      - name: Generate changelog
+        run: flopha changelog --to "${{ steps.version.outputs.tag }}" --output CHANGELOG.md
+
+      - name: Commit changelog
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --staged --quiet || git commit -m "chore: release ${{ steps.version.outputs.tag }}"
+          git push
+
+      - name: Create tag and release
+        uses: sjquant/flopha@v1
+        with:
+          auto: true
+          create-release: true
+```
+
+### Scripting with JSON output
+
+Every command supports `--format json` for safe, jq-parseable output:
+
+```bash
+# Extract version string
+flopha next-version --auto --format json | jq -r '.version'
+
+# List recent releases as JSON array
+flopha log --limit 5 --format json
+
+# Generate changelog as structured data
+flopha changelog --to "v2.0.0" --format json | jq '.groups[].title'
+```
+
+### Reusable release script
+
+A self-contained script suitable for any CI:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+NEXT=$(flopha next-version --auto --format json | jq -r '.version')
+echo "Releasing $NEXT"
+
+flopha changelog --to "$NEXT" --output CHANGELOG.md
+git add CHANGELOG.md
+git diff --staged --quiet || git commit -m "chore: release $NEXT"
+git push
+
+flopha next-version --auto --create
+git push origin "$NEXT"
+```


### PR DESCRIPTION
- `flopha changelog` generates a Markdown changelog grouped by
  Breaking Changes / Features / Bug Fixes / Other, sourced from
  conventional commits since the last (or a given) version tag.
  Supports --from, --output (write to file), --pattern, and --format.
- All commands (next-version, last-version, log, changelog) now accept
  --format json / --format text for machine-readable output.
- Adds serde_json dependency; all 34 existing tests still pass plus
  one new integration test for the changelog categorization logic.

https://claude.ai/code/session_01RoLtWCEUAh1y9Xqqnhr1tm