### PR TITLE
✨ Add --tag-message and --push flags to next-version --create

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,5 +4,5 @@
 
 ```sh
 cargo install prek
-prek install --hook-type pre-commit --hook-type commit-msg
+prek install
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,5 @@
 
 ```sh
 cargo install prek
-prek install
-prek install --hook-type commit-msg
+prek install --hook-type pre-commit --hook-type commit-msg
 ```
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,4 +8,3 @@ prek install
 prek install --hook-type commit-msg
 ```
 
-Commits and PR titles must start with a gitmoji (https://gitmoji.dev).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,16 +2,10 @@
 
 ## Setup
 
-After cloning, install dev tools and activate git hooks:
-
 ```sh
 cargo install prek
 prek install
 prek install --hook-type commit-msg
 ```
 
-Hooks enforce formatting (`cargo fmt`), linting (`cargo clippy`), secret detection, and [gitmoji](https://gitmoji.dev) commit messages.
-
-## Commit style
-
-All commits and PR titles must start with a gitmoji emoji followed by a space — e.g. `✨ Add feature`. See https://gitmoji.dev for the full list.
+Commits and PR titles must start with a gitmoji (https://gitmoji.dev).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# flopha
+
+## Setup
+
+After cloning, install dev tools and activate git hooks:
+
+```sh
+cargo install prek
+prek install
+prek install --hook-type commit-msg
+```
+
+Hooks enforce formatting (`cargo fmt`), linting (`cargo clippy`), secret detection, and [gitmoji](https://gitmoji.dev) commit messages.
+
+## Commit style
+
+All commits and PR titles must start with a gitmoji emoji followed by a space — e.g. `✨ Add feature`. See https://gitmoji.dev for the full list.

--- a/action/run.sh
+++ b/action/run.sh
@@ -43,11 +43,8 @@ fi
 PREV_TAG=$(flopha last-version --pattern "$INPUT_PATTERN" --format json | jq -r '.version // empty')
 
 # ── create and push the version tag ─────────────────────────────────────────
-NEW_TAG=$(flopha next-version "${ARGS[@]}" --create)
-
-if ! PUSH_OUT=$(git push origin "$NEW_TAG" 2>&1); then
-  git tag -d "$NEW_TAG" 2>/dev/null || true
-  echo "::error::Failed to push tag '$NEW_TAG': $PUSH_OUT"
+if ! NEW_TAG=$(flopha next-version "${ARGS[@]}" --create --push); then
+  echo "::error::Failed to create or push tag."
   echo "::error::Make sure the calling workflow has 'permissions: contents: write'."
   exit 1
 fi

--- a/action/run.sh
+++ b/action/run.sh
@@ -44,7 +44,7 @@ PREV_TAG=$(flopha last-version --pattern "$INPUT_PATTERN" --format json | jq -r 
 
 # ── create and push the version tag ─────────────────────────────────────────
 if ! NEW_TAG=$(flopha next-version "${ARGS[@]}" --create --push); then
-  echo "::error::Failed to create or push tag."
+  echo "::error::Failed to create or push tag '$NEW_TAG'."
   echo "::error::Make sure the calling workflow has 'permissions: contents: write'."
   exit 1
 fi

--- a/prek.toml
+++ b/prek.toml
@@ -1,5 +1,7 @@
 #:schema https://www.schemastore.org/prek.json
 
+default_install_hook_types = ["pre-commit", "commit-msg"]
+
 [[repos]]
 repo = "builtin"
 hooks = [

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -108,7 +108,7 @@ pub struct NextVersionArgs {
     )]
     pub tag_message: Option<String>,
     #[clap(
-        help = "Push the created tag or branch to 'origin' after creation",
+        help = "Push the tag or branch created by --create to 'origin'",
         long,
         action,
         requires = "create"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,6 +102,19 @@ pub struct NextVersionArgs {
     )]
     pub create: bool,
     #[clap(
+        help = "Annotated tag message; when set an annotated tag is created instead of a lightweight one",
+        long,
+        requires = "create"
+    )]
+    pub tag_message: Option<String>,
+    #[clap(
+        help = "Push the created tag or branch to 'origin' after creation",
+        long,
+        action,
+        requires = "create"
+    )]
+    pub push: bool,
+    #[clap(
         help = "Specify the source for versioning: tag (default) or branch",
         long,
         short = 's',

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,4 +22,6 @@ pub enum FlophaError {
     InvalidRule { input: String, reason: String },
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+    #[error("invalid argument: {0}")]
+    InvalidArgs(String),
 }

--- a/src/gitutils.rs
+++ b/src/gitutils.rs
@@ -25,6 +25,17 @@ pub fn tag_oid(repo: &Repository, id: git2::Oid, tagname: &str) -> Result<git2::
     repo.tag_lightweight(tagname, &obj, true)
 }
 
+pub fn annotated_tag_oid(
+    repo: &Repository,
+    id: git2::Oid,
+    tagname: &str,
+    message: &str,
+) -> Result<git2::Oid, git2::Error> {
+    let obj = repo.find_object(id, None)?;
+    let sig = repo.signature()?;
+    repo.tag(tagname, &obj, &sig, message, true)
+}
+
 pub fn commit(repo: &Repository, message: &str) -> Result<git2::Oid, git2::Error> {
     let mut index = repo.index()?;
     let id = index.write_tree()?;

--- a/src/service.rs
+++ b/src/service.rs
@@ -40,6 +40,14 @@ pub fn last_version(path: &Path, args: &LastVersionArgs) -> Result<Option<String
 }
 
 pub fn next_version(path: &Path, args: &NextVersionArgs) -> Result<Option<String>, FlophaError> {
+    if args.tag_message.is_some() {
+        if let VersionSourceName::Branch = args.source {
+            return Err(FlophaError::InvalidArgs(
+                "--tag-message is only valid with --source tag".to_string(),
+            ));
+        }
+    }
+
     let repo = gitutils::get_repo(path)?;
     try_fetch_from_origin(&repo);
     let pattern = args
@@ -1186,5 +1194,134 @@ mod tests {
         let json = serde_json::json!({"version": tricky}).to_string();
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["version"], tricky);
+    }
+
+    #[test]
+    fn test_next_version_annotated_tag_created_when_tag_message_set() {
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, mut remote) = testutils::init_remote(&repo);
+
+        create_new_remote_tag(&repo, &mut remote, "v1.0.0", false);
+        gitutils::checkout_tag(&repo, "v1.0.0").unwrap();
+        gitutils::commit(&repo, "fix: something").unwrap();
+
+        let args = NextVersionArgs {
+            pattern: Some("v{major}.{minor}.{patch}".to_string()),
+            increment: Increment::Patch,
+            auto: false,
+            rule: vec![],
+            pre: None,
+            source: VersionSourceName::Tag,
+            create: true,
+            tag_message: Some("Release v1.0.1".to_string()),
+            push: false,
+            format: OutputFormat::Text,
+        };
+        next_version(td.path(), &args).unwrap();
+
+        let tag_obj = repo.revparse_single("refs/tags/v1.0.1").unwrap();
+        assert_eq!(
+            tag_obj.kind(),
+            Some(git2::ObjectType::Tag),
+            "expected annotated tag object"
+        );
+    }
+
+    #[test]
+    fn test_tag_message_with_branch_source_returns_error() {
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, mut remote) = testutils::init_remote(&repo);
+
+        create_new_remote_branch(&repo, &mut remote, "release/1.0.0");
+        gitutils::checkout_branch(&repo, "release/1.0.0", false).unwrap();
+        gitutils::commit(&repo, "New commit").unwrap();
+
+        let args = NextVersionArgs {
+            pattern: Some("release/{major}.{minor}.{patch}".to_string()),
+            increment: Increment::Patch,
+            auto: false,
+            rule: vec![],
+            pre: None,
+            source: VersionSourceName::Branch,
+            create: true,
+            tag_message: Some("should fail".to_string()),
+            push: false,
+            format: OutputFormat::Text,
+        };
+        let result = next_version(td.path(), &args);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("--tag-message is only valid with --source tag"));
+    }
+
+    #[test]
+    fn test_next_version_push_tag_reaches_remote() {
+        let (td, repo) = testutils::init_repo();
+        let (remote_td, mut remote) = testutils::init_remote(&repo);
+
+        create_new_remote_tag(&repo, &mut remote, "v1.0.0", false);
+        gitutils::checkout_tag(&repo, "v1.0.0").unwrap();
+        gitutils::commit(&repo, "fix: something").unwrap();
+
+        let args = NextVersionArgs {
+            pattern: Some("v{major}.{minor}.{patch}".to_string()),
+            increment: Increment::Patch,
+            auto: false,
+            rule: vec![],
+            pre: None,
+            source: VersionSourceName::Tag,
+            create: true,
+            tag_message: None,
+            push: true,
+            format: OutputFormat::Text,
+        };
+        next_version(td.path(), &args).unwrap();
+
+        let remote_repo = git2::Repository::open(remote_td.path()).unwrap();
+        let tag_names = remote_repo.tag_names(None).unwrap();
+        assert!(
+            tag_names.iter().any(|t| t == Some("v1.0.1")),
+            "v1.0.1 tag should have been pushed to remote"
+        );
+    }
+
+    #[test]
+    fn test_next_version_push_branch_reaches_remote() {
+        let (td, repo) = testutils::init_repo();
+        let (remote_td, mut remote) = testutils::init_remote(&repo);
+
+        for branch in ["release/1.0.0", "release/2.0.0"] {
+            create_new_remote_branch(&repo, &mut remote, branch);
+        }
+        gitutils::checkout_branch(&repo, "release/2.0.0", false).unwrap();
+        gitutils::commit(&repo, "New commit").unwrap();
+
+        let args = NextVersionArgs {
+            pattern: Some("release/{major}.{minor}.{patch}".to_string()),
+            increment: Increment::Minor,
+            auto: false,
+            rule: vec![],
+            pre: None,
+            source: VersionSourceName::Branch,
+            create: true,
+            tag_message: None,
+            push: true,
+            format: OutputFormat::Text,
+        };
+        next_version(td.path(), &args).unwrap();
+
+        let remote_repo = git2::Repository::open(remote_td.path()).unwrap();
+        let branches = remote_repo
+            .branches(Some(git2::BranchType::Local))
+            .unwrap();
+        assert!(
+            branches.into_iter().any(|b| {
+                let (branch, _) = b.unwrap();
+                branch.name().unwrap() == Some("release/2.1.0")
+            }),
+            "release/2.1.0 branch should have been pushed to remote"
+        );
     }
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -104,8 +104,7 @@ pub fn next_version(path: &Path, args: &NextVersionArgs) -> Result<Option<String
             match args.source {
                 VersionSourceName::Tag => gitutils::push_tag(&mut remote, &final_tag)?,
                 VersionSourceName::Branch => {
-                    let mut branch =
-                        repo.find_branch(&final_tag, git2::BranchType::Local)?;
+                    let mut branch = repo.find_branch(&final_tag, git2::BranchType::Local)?;
                     gitutils::push_branch(&mut remote, &mut branch)?;
                 }
             }
@@ -1313,9 +1312,7 @@ mod tests {
         next_version(td.path(), &args).unwrap();
 
         let remote_repo = git2::Repository::open(remote_td.path()).unwrap();
-        let branches = remote_repo
-            .branches(Some(git2::BranchType::Local))
-            .unwrap();
+        let branches = remote_repo.branches(Some(git2::BranchType::Local)).unwrap();
         assert!(
             branches.into_iter().any(|b| {
                 let (branch, _) = b.unwrap();

--- a/src/service.rs
+++ b/src/service.rs
@@ -89,7 +89,19 @@ pub fn next_version(path: &Path, args: &NextVersionArgs) -> Result<Option<String
     }
 
     if args.create {
-        version_source.create(&repo, &final_tag)?;
+        version_source.create(&repo, &final_tag, args.tag_message.as_deref())?;
+
+        if args.push {
+            let mut remote = gitutils::get_remote(&repo, "origin")?;
+            match args.source {
+                VersionSourceName::Tag => gitutils::push_tag(&mut remote, &final_tag)?,
+                VersionSourceName::Branch => {
+                    let mut branch =
+                        repo.find_branch(&final_tag, git2::BranchType::Local)?;
+                    gitutils::push_branch(&mut remote, &mut branch)?;
+                }
+            }
+        }
     }
 
     Ok(Some(final_tag))
@@ -737,6 +749,8 @@ mod tests {
             source: VersionSourceName::Tag,
             create: false,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -770,6 +784,8 @@ mod tests {
             source: VersionSourceName::Tag,
             create: true,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
         next_version(td.path(), &args).unwrap();
 
@@ -808,6 +824,8 @@ mod tests {
             source: VersionSourceName::Branch,
             create: false,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -833,6 +851,8 @@ mod tests {
             source: VersionSourceName::Branch,
             create: false,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
 
         let result = next_version(td.path(), &args).unwrap();
@@ -861,6 +881,8 @@ mod tests {
             source: VersionSourceName::Branch,
             create: true,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -894,6 +916,8 @@ mod tests {
             source: VersionSourceName::Tag,
             create: false,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -921,6 +945,8 @@ mod tests {
             source: VersionSourceName::Tag,
             create: false,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -948,6 +974,8 @@ mod tests {
             source: VersionSourceName::Tag,
             create: false,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
         let result = next_version(td.path(), &args).unwrap();
 
@@ -975,6 +1003,8 @@ mod tests {
             source: VersionSourceName::Tag,
             create: false,
             format: OutputFormat::Text,
+            tag_message: None,
+            push: false,
         };
         let result = next_version(td.path(), &args).unwrap();
 

--- a/src/version_source.rs
+++ b/src/version_source.rs
@@ -4,7 +4,12 @@ use git2::Repository;
 pub trait VersionSource {
     fn fetch_all(&self, repo: &Repository) -> Vec<String>;
     fn checkout(&self, repo: &Repository, version: &str) -> Result<(), git2::Error>;
-    fn create(&self, repo: &Repository, version: &str) -> Result<(), git2::Error>;
+    fn create(
+        &self,
+        repo: &Repository,
+        version: &str,
+        tag_message: Option<&str>,
+    ) -> Result<(), git2::Error>;
 }
 
 pub struct TagVersionSource;
@@ -28,9 +33,18 @@ impl VersionSource for TagVersionSource {
         gitutils::checkout_tag(repo, version)
     }
 
-    fn create(&self, repo: &Repository, version: &str) -> Result<(), git2::Error> {
+    fn create(
+        &self,
+        repo: &Repository,
+        version: &str,
+        tag_message: Option<&str>,
+    ) -> Result<(), git2::Error> {
         let commit = repo.head()?.peel_to_commit()?;
-        gitutils::tag_oid(repo, commit.id(), version)?;
+        if let Some(msg) = tag_message {
+            gitutils::annotated_tag_oid(repo, commit.id(), version, msg)?;
+        } else {
+            gitutils::tag_oid(repo, commit.id(), version)?;
+        }
         Ok(())
     }
 }
@@ -53,7 +67,12 @@ impl VersionSource for BranchVersionSource {
         gitutils::checkout_branch(repo, version, false)
     }
 
-    fn create(&self, repo: &Repository, version: &str) -> Result<(), git2::Error> {
+    fn create(
+        &self,
+        repo: &Repository,
+        version: &str,
+        _tag_message: Option<&str>,
+    ) -> Result<(), git2::Error> {
         gitutils::checkout_branch(repo, version, true)
     }
 }


### PR DESCRIPTION
--tag-message <MSG> creates an annotated tag instead of a lightweight
one when --create is used with the default tag source.

--push pushes the newly created tag or branch to 'origin' immediately
after creation, eliminating the separate `git push origin <tag>` step.

Both new flags require --create.