### PR TITLE
✨ Changelog CI integration and --to range support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
               --group 'Bug Fixes:^(🐛|🚑)' \
               --group 'Performance:^⚡' \
               --group 'Refactoring:^♻' \
-              --group 'Documentation:^📝' || true
+              --group 'Documentation:^📝'
             echo "${CL_EOF}"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,15 @@ jobs:
           CL_EOF="__FLOPHA_CL_${RANDOM}${RANDOM}__"
           {
             echo "changelog<<${CL_EOF}"
-            [ -n "$prev_tag" ] && flopha changelog --from "$prev_tag" --to HEAD || true
+            if [ -n "$prev_tag" ]; then
+              flopha changelog --from "$prev_tag" --to HEAD \
+                --group 'Breaking Changes:^💥' \
+                --group 'New Features:^✨' \
+                --group 'Bug Fixes:^(🐛|🚑)' \
+                --group 'Performance:^⚡' \
+                --group 'Refactoring:^♻' \
+                --group 'Documentation:^📝' || true
+            fi
             echo "${CL_EOF}"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,7 @@ jobs:
         if: steps.version_check.outputs.should_release == 'true'
         shell: bash
         run: |
-          export PATH="${HOME}/.flopha/bin:${PATH}"
-          prev_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          prev_tag=$(flopha lv --pattern 'v{major}.{minor}.{patch}' --format json | jq -r '.version // empty')
           CL_ARGS=(--to "v${{ steps.version_check.outputs.new_version }}")
           [ -n "$prev_tag" ] && CL_ARGS+=(--from "$prev_tag")
           CL_EOF="__FLOPHA_CL_${RANDOM}${RANDOM}__"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         shell: bash
         run: |
           prev_tag=$(flopha lv --pattern 'v{major}.{minor}.{patch}' --format json | jq -r '.version // empty')
-          CL_ARGS=(--to "v${{ steps.version_check.outputs.new_version }}")
+          CL_ARGS=(--title "Changes in v${{ steps.version_check.outputs.new_version }}")
           [ -n "$prev_tag" ] && CL_ARGS+=(--from "$prev_tag")
           CL_EOF="__FLOPHA_CL_${RANDOM}${RANDOM}__"
           {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,12 @@ jobs:
     outputs:
       should_release: ${{ steps.version_check.outputs.should_release }}
       new_version: ${{ steps.version_check.outputs.new_version }}
+      changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check version
         id: version_check
@@ -34,13 +37,33 @@ jobs:
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Install flopha
+        if: steps.version_check.outputs.should_release == 'true'
+        env:
+          FLOPHA_VERSION: latest
+        run: bash action/install.sh
+
+      - name: Generate changelog
+        id: changelog
+        if: steps.version_check.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          export PATH="${HOME}/.flopha/bin:${PATH}"
+          prev_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          CL_EOF="__FLOPHA_CL_${RANDOM}${RANDOM}__"
+          {
+            echo "changelog<<${CL_EOF}"
+            [ -n "$prev_tag" ] && flopha changelog --from "$prev_tag" --to HEAD || true
+            echo "${CL_EOF}"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create draft release
         if: steps.version_check.outputs.should_release == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version_check.outputs.new_version }}
           draft: true
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.changelog }}
 
   build-release:
     needs: prepare-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,18 +50,18 @@ jobs:
         run: |
           export PATH="${HOME}/.flopha/bin:${PATH}"
           prev_tag=$(git tag --list 'v*' --sort=-version:refname | head -1)
+          CL_ARGS=(--to "v${{ steps.version_check.outputs.new_version }}")
+          [ -n "$prev_tag" ] && CL_ARGS+=(--from "$prev_tag")
           CL_EOF="__FLOPHA_CL_${RANDOM}${RANDOM}__"
           {
             echo "changelog<<${CL_EOF}"
-            if [ -n "$prev_tag" ]; then
-              flopha changelog --from "$prev_tag" --to HEAD \
-                --group 'Breaking Changes:^💥' \
-                --group 'New Features:^✨' \
-                --group 'Bug Fixes:^(🐛|🚑)' \
-                --group 'Performance:^⚡' \
-                --group 'Refactoring:^♻' \
-                --group 'Documentation:^📝' || true
-            fi
+            flopha changelog "${CL_ARGS[@]}" \
+              --group 'Breaking Changes:^💥' \
+              --group 'New Features:^✨' \
+              --group 'Bug Fixes:^(🐛|🚑)' \
+              --group 'Performance:^⚡' \
+              --group 'Refactoring:^♻' \
+              --group 'Documentation:^📝' || true
             echo "${CL_EOF}"
           } >> "$GITHUB_OUTPUT"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,4 +7,4 @@ cargo install prek
 prek install
 ```
 
-Run `prek install` at the start of every session before committing.
+Run `prek install -f` at the start of every session before committing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,3 +6,5 @@
 cargo install prek
 prek install
 ```
+
+Run `prek install` at the start of every session before committing.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "flopha"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.74.0"
 exclude = ["assets/brand/**"]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -242,9 +242,10 @@ pub struct ChangelogArgs {
     )]
     pub title: Option<String>,
     #[clap(
-        help = "Target version label for this changelog entry (e.g. v1.2.3). \
-                Display-only: does not affect which commits are included (use --from for that). \
-                The tag does not need to exist yet. Exposed as {to} in the --title template.",
+        help = "Upper bound for the changelog (e.g. v1.2.3). When the tag exists it limits \
+                which commits are included; when it does not exist yet (e.g. in CI before \
+                tagging) it falls back to HEAD and is used as a display label only. \
+                Exposed as {to} in the --title template.",
         long
     )]
     pub to: Option<String>,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -242,10 +242,9 @@ pub struct ChangelogArgs {
     )]
     pub title: Option<String>,
     #[clap(
-        help = "Upper bound for the changelog (e.g. v1.2.3). When the tag exists it limits \
-                which commits are included; when it does not exist yet (e.g. in CI before \
-                tagging) it falls back to HEAD and is used as a display label only. \
-                Exposed as {to} in the --title template.",
+        help = "Upper bound for the changelog (e.g. v1.2.3). The tag must exist. \
+                Limits which commits are included and is exposed as {to} in the --title template. \
+                Use --title directly when the tag does not exist yet (e.g. in CI before tagging).",
         long
     )]
     pub to: Option<String>,

--- a/src/gitutils.rs
+++ b/src/gitutils.rs
@@ -249,6 +249,7 @@ pub struct CommitInfo {
 pub fn commits_since_tag_with_info(
     repo: &Repository,
     tag_name: &str,
+    to: Option<&str>,
 ) -> Result<Vec<CommitInfo>, git2::Error> {
     let tag_obj = repo
         .revparse_single(&format!("refs/tags/{}", tag_name))
@@ -257,7 +258,7 @@ pub fn commits_since_tag_with_info(
     let tag_commit_oid = tag_obj.peel_to_commit()?.id();
 
     let mut revwalk = repo.revwalk()?;
-    revwalk.push_head()?;
+    push_revwalk_start(repo, &mut revwalk, to)?;
     revwalk.hide(tag_commit_oid)?;
     revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
 
@@ -276,10 +277,13 @@ pub fn commits_since_tag_with_info(
     Ok(commits)
 }
 
-/// Returns every commit reachable from HEAD, used when there is no prior tag.
-pub fn all_commits_with_info(repo: &Repository) -> Result<Vec<CommitInfo>, git2::Error> {
+/// Returns every commit reachable from HEAD (or `to` if it resolves), used when there is no prior tag.
+pub fn all_commits_with_info(
+    repo: &Repository,
+    to: Option<&str>,
+) -> Result<Vec<CommitInfo>, git2::Error> {
     let mut revwalk = repo.revwalk()?;
-    revwalk.push_head()?;
+    push_revwalk_start(repo, &mut revwalk, to)?;
     revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
 
     let mut commits = Vec::new();
@@ -295,6 +299,24 @@ pub fn all_commits_with_info(repo: &Repository) -> Result<Vec<CommitInfo>, git2:
         }
     }
     Ok(commits)
+}
+
+/// Pushes the revwalk start point: the `to` tag's commit when it resolves, HEAD otherwise.
+fn push_revwalk_start(
+    repo: &Repository,
+    revwalk: &mut git2::Revwalk,
+    to: Option<&str>,
+) -> Result<(), git2::Error> {
+    match to {
+        Some(to_ref) => match repo
+            .revparse_single(&format!("refs/tags/{}", to_ref))
+            .or_else(|_| repo.revparse_single(to_ref))
+        {
+            Ok(obj) => revwalk.push(obj.peel_to_commit()?.id()),
+            Err(_) => revwalk.push_head(),
+        },
+        None => revwalk.push_head(),
+    }
 }
 
 /// Returns commit messages for every commit reachable from HEAD that was made

--- a/src/gitutils.rs
+++ b/src/gitutils.rs
@@ -301,7 +301,8 @@ pub fn all_commits_with_info(
     Ok(commits)
 }
 
-/// Pushes the revwalk start point: the `to` tag's commit when it resolves, HEAD otherwise.
+/// Pushes the revwalk start point to the `to` tag's commit, or HEAD when `to` is None.
+/// Returns an error if `to` is given but does not resolve to a known git object.
 fn push_revwalk_start(
     repo: &Repository,
     revwalk: &mut git2::Revwalk,
@@ -313,7 +314,10 @@ fn push_revwalk_start(
             .or_else(|_| repo.revparse_single(to_ref))
         {
             Ok(obj) => revwalk.push(obj.peel_to_commit()?.id()),
-            Err(_) => revwalk.push_head(),
+            Err(_) => Err(git2::Error::from_str(&format!(
+                "tag '{}' not found",
+                to_ref
+            ))),
         },
         None => revwalk.push_head(),
     }

--- a/src/gitutils.rs
+++ b/src/gitutils.rs
@@ -277,7 +277,7 @@ pub fn commits_since_tag_with_info(
     Ok(commits)
 }
 
-/// Returns every commit reachable from HEAD (or `to` if it resolves), used when there is no prior tag.
+/// Returns every commit reachable from `to` (or HEAD when `to` is None), used when there is no prior tag.
 pub fn all_commits_with_info(
     repo: &Repository,
     to: Option<&str>,
@@ -314,10 +314,7 @@ fn push_revwalk_start(
             .or_else(|_| repo.revparse_single(to_ref))
         {
             Ok(obj) => revwalk.push(obj.peel_to_commit()?.id()),
-            Err(_) => Err(git2::Error::from_str(&format!(
-                "tag '{}' not found",
-                to_ref
-            ))),
+            Err(_) => Err(git2::Error::from_str(&format!("'{}' not found", to_ref))),
         },
         None => revwalk.push_head(),
     }

--- a/src/gitutils.rs
+++ b/src/gitutils.rs
@@ -276,6 +276,27 @@ pub fn commits_since_tag_with_info(
     Ok(commits)
 }
 
+/// Returns every commit reachable from HEAD, used when there is no prior tag.
+pub fn all_commits_with_info(repo: &Repository) -> Result<Vec<CommitInfo>, git2::Error> {
+    let mut revwalk = repo.revwalk()?;
+    revwalk.push_head()?;
+    revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+
+    let mut commits = Vec::new();
+    for oid in revwalk {
+        let oid = oid?;
+        let commit = repo.find_commit(oid)?;
+        if let Some(msg) = commit.message() {
+            let id_str = oid.to_string();
+            commits.push(CommitInfo {
+                short_id: id_str[..7.min(id_str.len())].to_string(),
+                message: msg.to_string(),
+            });
+        }
+    }
+    Ok(commits)
+}
+
 /// Returns commit messages for every commit reachable from HEAD that was made
 /// *after* the given tag (i.e., not included in the tagged commit or its ancestors).
 pub fn commits_since_tag(repo: &Repository, tag_name: &str) -> Result<Vec<String>, git2::Error> {

--- a/src/service.rs
+++ b/src/service.rs
@@ -242,8 +242,8 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
 
     let group_rules = build_group_rules(&args.group)?;
     let commits = match &from_tag {
-        Some(tag) => gitutils::commits_since_tag_with_info(&repo, tag)?,
-        None => gitutils::all_commits_with_info(&repo)?,
+        Some(tag) => gitutils::commits_since_tag_with_info(&repo, tag, args.to.as_deref())?,
+        None => gitutils::all_commits_with_info(&repo, args.to.as_deref())?,
     };
 
     // Pre-build ordered section labels from the rules (deduplicated).
@@ -1073,6 +1073,48 @@ mod tests {
 
         // Custom rules should categorize without error.
         changelog(td.path(), &args).unwrap();
+    }
+
+    #[test]
+    fn test_changelog_historical_range() {
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, mut remote) = testutils::init_remote(&repo);
+
+        create_new_remote_tag(&repo, &mut remote, "v1.0.0", false);
+        gitutils::commit(&repo, "✨ Add feature A").unwrap();
+        gitutils::commit(&repo, "🐛 Fix bug B").unwrap();
+        create_new_remote_tag(&repo, &mut remote, "v1.1.0", false);
+        // commits after v1.1.0 — should NOT appear in the v1.0.0..v1.1.0 slice
+        gitutils::commit(&repo, "✨ Add feature C").unwrap();
+
+        let args = ChangelogArgs {
+            from: Some("v1.0.0".to_string()),
+            to: Some("v1.1.0".to_string()),
+            pattern: Some("v{major}.{minor}.{patch}".to_string()),
+            source: VersionSourceName::Tag,
+            group: vec![],
+            other: None,
+            title: None,
+            overwrite: false,
+            output: Some(format!("{}/out.txt", td.path().display())),
+            format: OutputFormat::Text,
+        };
+
+        changelog(td.path(), &args).unwrap();
+
+        let content = std::fs::read_to_string(format!("{}/out.txt", td.path().display())).unwrap();
+        assert!(
+            content.contains("feature A"),
+            "should include commits up to v1.1.0"
+        );
+        assert!(
+            content.contains("bug B"),
+            "should include commits up to v1.1.0"
+        );
+        assert!(
+            !content.contains("feature C"),
+            "should exclude commits after v1.1.0"
+        );
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -1138,8 +1138,22 @@ mod tests {
             format: OutputFormat::Text,
         };
 
-        // Should walk full history and produce output without error.
+        let out_path = format!("{}/out.txt", td.path().display());
+        let args = ChangelogArgs {
+            output: Some(out_path.clone()),
+            ..args
+        };
         changelog(td.path(), &args).unwrap();
+
+        let content = std::fs::read_to_string(&out_path).unwrap();
+        assert!(
+            content.contains("initial feature"),
+            "should include all commits when no prior tag"
+        );
+        assert!(
+            content.contains("startup crash"),
+            "should include all commits when no prior tag"
+        );
     }
 
     #[test]

--- a/src/service.rs
+++ b/src/service.rs
@@ -233,24 +233,18 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
         .clone()
         .unwrap_or("v{major}.{minor}.{patch}".to_string());
 
-    let from_tag = if let Some(ref from) = args.from {
-        from.clone()
+    let from_tag: Option<String> = if let Some(ref from) = args.from {
+        Some(from.clone())
     } else {
         let versioner = versioner_factory(&repo, pattern, &args.source);
-        match versioner.last_version() {
-            Some(v) => v.tag,
-            None => {
-                match args.format {
-                    OutputFormat::Json => println!("null"),
-                    OutputFormat::Text => println!("No version found"),
-                }
-                return Ok(());
-            }
-        }
+        versioner.last_version().map(|v| v.tag)
     };
 
     let group_rules = build_group_rules(&args.group)?;
-    let commits = gitutils::commits_since_tag_with_info(&repo, &from_tag)?;
+    let commits = match &from_tag {
+        Some(tag) => gitutils::commits_since_tag_with_info(&repo, tag)?,
+        None => gitutils::all_commits_with_info(&repo)?,
+    };
 
     // Pre-build ordered section labels from the rules (deduplicated).
     let mut group_order: Vec<String> = Vec::new();
@@ -311,17 +305,20 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
                     "--title contains {{to}} but --to was not supplied; placeholder will be empty"
                 );
             }
-            t.replace("{from}", &from_tag)
+            t.replace("{from}", from_tag.as_deref().unwrap_or(""))
                 .replace("{to}", args.to.as_deref().unwrap_or(""))
         }
         None => match &args.to {
             Some(to) => format!("Changes in {}", to),
-            None => format!("Changelog since {}", from_tag),
+            None => match &from_tag {
+                Some(from) => format!("Changelog since {}", from),
+                None => "Initial Changelog".to_string(),
+            },
         },
     };
 
     let content = match args.format {
-        OutputFormat::Json => format_changelog_json(&title, &from_tag, args.to.as_deref(), &groups),
+        OutputFormat::Json => format_changelog_json(&title, from_tag.as_deref().unwrap_or(""), args.to.as_deref(), &groups),
         OutputFormat::Text => format_changelog_text(&title, &groups),
     };
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -318,7 +318,9 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     };
 
     let content = match args.format {
-        OutputFormat::Json => format_changelog_json(&title, from_tag.as_deref(), args.to.as_deref(), &groups),
+        OutputFormat::Json => {
+            format_changelog_json(&title, from_tag.as_deref(), args.to.as_deref(), &groups)
+        }
         OutputFormat::Text => format_changelog_text(&title, &groups),
     };
 
@@ -1085,10 +1087,7 @@ mod tests {
             from: None,
             pattern: Some("v{major}.{minor}.{patch}".to_string()),
             source: VersionSourceName::Tag,
-            group: vec![
-                "New Features:^✨".to_string(),
-                "Bug Fixes:^🐛".to_string(),
-            ],
+            group: vec!["New Features:^✨".to_string(), "Bug Fixes:^🐛".to_string()],
             other: None,
             title: None,
             to: Some("v0.1.0".to_string()),
@@ -1231,7 +1230,8 @@ mod tests {
                 hash: "abc1234".to_string(),
             }],
         )];
-        let json = format_changelog_json("Changes in v1.1.0", Some("v1.0.0"), Some("v1.1.0"), &groups);
+        let json =
+            format_changelog_json("Changes in v1.1.0", Some("v1.0.0"), Some("v1.1.0"), &groups);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["title"], "Changes in v1.1.0");
         assert_eq!(v["from"], "v1.0.0");

--- a/src/service.rs
+++ b/src/service.rs
@@ -1132,7 +1132,7 @@ mod tests {
             group: vec!["New Features:^✨".to_string(), "Bug Fixes:^🐛".to_string()],
             other: None,
             title: None,
-            to: Some("v0.1.0".to_string()),
+            to: None,
             overwrite: false,
             output: None,
             format: OutputFormat::Text,
@@ -1156,7 +1156,7 @@ mod tests {
             group: vec![],
             other: None,
             title: None,
-            to: Some("v0.1.0".to_string()),
+            to: None,
             overwrite: false,
             output: Some(format!("{}/out.json", td.path().display())),
             format: OutputFormat::Json,
@@ -1167,7 +1167,29 @@ mod tests {
         let content = std::fs::read_to_string(format!("{}/out.json", td.path().display())).unwrap();
         let v: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
         assert!(v["from"].is_null(), "from should be null when no prior tag");
-        assert_eq!(v["to"], "v0.1.0");
+    }
+
+    #[test]
+    fn test_changelog_to_nonexistent_tag_errors() {
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, _remote) = testutils::init_remote(&repo);
+
+        gitutils::commit(&repo, "✨ Add feature").unwrap();
+
+        let args = ChangelogArgs {
+            from: None,
+            pattern: Some("v{major}.{minor}.{patch}".to_string()),
+            source: VersionSourceName::Tag,
+            group: vec![],
+            other: None,
+            title: None,
+            to: Some("v99.0.0".to_string()),
+            overwrite: false,
+            output: None,
+            format: OutputFormat::Text,
+        };
+
+        assert!(changelog(td.path(), &args).is_err());
     }
 
     fn create_new_remote_tag(

--- a/src/service.rs
+++ b/src/service.rs
@@ -318,7 +318,7 @@ pub fn changelog(path: &Path, args: &ChangelogArgs) -> Result<(), FlophaError> {
     };
 
     let content = match args.format {
-        OutputFormat::Json => format_changelog_json(&title, from_tag.as_deref().unwrap_or(""), args.to.as_deref(), &groups),
+        OutputFormat::Json => format_changelog_json(&title, from_tag.as_deref(), args.to.as_deref(), &groups),
         OutputFormat::Text => format_changelog_text(&title, &groups),
     };
 
@@ -402,7 +402,7 @@ fn format_changelog_text(title: &str, groups: &[(String, Vec<ChangelogEntry>)]) 
 
 fn format_changelog_json(
     title: &str,
-    from: &str,
+    from: Option<&str>,
     to: Option<&str>,
     groups: &[(String, Vec<ChangelogEntry>)],
 ) -> String {
@@ -1073,6 +1073,62 @@ mod tests {
         changelog(td.path(), &args).unwrap();
     }
 
+    #[test]
+    fn test_changelog_no_prior_tag() {
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, _remote) = testutils::init_remote(&repo);
+
+        gitutils::commit(&repo, "✨ Add initial feature").unwrap();
+        gitutils::commit(&repo, "🐛 Fix startup crash").unwrap();
+
+        let args = ChangelogArgs {
+            from: None,
+            pattern: Some("v{major}.{minor}.{patch}".to_string()),
+            source: VersionSourceName::Tag,
+            group: vec![
+                "New Features:^✨".to_string(),
+                "Bug Fixes:^🐛".to_string(),
+            ],
+            other: None,
+            title: None,
+            to: Some("v0.1.0".to_string()),
+            overwrite: false,
+            output: None,
+            format: OutputFormat::Text,
+        };
+
+        // Should walk full history and produce output without error.
+        changelog(td.path(), &args).unwrap();
+    }
+
+    #[test]
+    fn test_changelog_no_prior_tag_json_from_is_null() {
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, _remote) = testutils::init_remote(&repo);
+
+        gitutils::commit(&repo, "✨ Add initial feature").unwrap();
+
+        let args = ChangelogArgs {
+            from: None,
+            pattern: Some("v{major}.{minor}.{patch}".to_string()),
+            source: VersionSourceName::Tag,
+            group: vec![],
+            other: None,
+            title: None,
+            to: Some("v0.1.0".to_string()),
+            overwrite: false,
+            output: Some(format!("{}/out.json", td.path().display())),
+            format: OutputFormat::Json,
+        };
+
+        changelog(td.path(), &args).unwrap();
+
+        let content = std::fs::read_to_string(format!("{}/out.json", td.path().display())).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
+        assert!(v["from"].is_null(), "from should be null when no prior tag");
+        assert_eq!(v["to"], "v0.1.0");
+    }
+
     fn create_new_remote_tag(
         repo: &git2::Repository,
         remote: &mut git2::Remote,
@@ -1115,7 +1171,7 @@ mod tests {
                 }],
             ),
         ];
-        let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", None, &groups);
+        let json = format_changelog_json("Changelog since v1.0.0", Some("v1.0.0"), None, &groups);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
 
         assert_eq!(v["title"], "Changelog since v1.0.0");
@@ -1139,7 +1195,7 @@ mod tests {
         )];
         let json = format_changelog_json(
             r#"Release v1.0.0"edge""#,
-            r#"v1.0.0"edge"#,
+            Some(r#"v1.0.0"edge"#),
             Some(r#"v1.0.0"edge""#),
             &groups,
         );
@@ -1159,7 +1215,7 @@ mod tests {
 
     #[test]
     fn test_changelog_json_empty_groups() {
-        let json = format_changelog_json("Changelog since v1.0.0", "v1.0.0", None, &[]);
+        let json = format_changelog_json("Changelog since v1.0.0", Some("v1.0.0"), None, &[]);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["from"], "v1.0.0");
         assert!(v.get("to").is_none());
@@ -1175,7 +1231,7 @@ mod tests {
                 hash: "abc1234".to_string(),
             }],
         )];
-        let json = format_changelog_json("Changes in v1.1.0", "v1.0.0", Some("v1.1.0"), &groups);
+        let json = format_changelog_json("Changes in v1.1.0", Some("v1.0.0"), Some("v1.1.0"), &groups);
         let v: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
         assert_eq!(v["title"], "Changes in v1.1.0");
         assert_eq!(v["from"], "v1.0.0");


### PR DESCRIPTION
## Summary

- **Changelog in CI**: `release.yml` now runs `flopha changelog` in the `prepare-release` job and uses the output as the GitHub release body, replacing GitHub's auto-generated release notes. Groups are gitmoji-based (💥 Breaking, ✨ Features, 🐛/🚑 Fixes, ⚡ Performance, ♻ Refactoring, 📝 Docs).
- **Initial release support**: When no prior tag exists, `flopha changelog` now walks full history instead of bailing with "No version found".
- **`--to` range support**: `--to` now limits the commit range when the tag exists, enabling historical changelog slices (e.g. `--from v1.0.0 --to v1.1.0`). Errors if the tag doesn't exist — use `--title` directly for unreleased versions (as the CI workflow does).
- **JSON `from` field**: Correctly emits `null` instead of `""` when there is no prior tag.
- **`flopha lv` in workflow**: Replaced raw `git tag` sort with `flopha lv --format json` for pattern-aware previous tag resolution.
- **CLAUDE.md**: Added reminder to run `prek install -f` at the start of every session.
- **Version bump**: `0.3.0` → `0.4.0`

## Test plan

- [ ] `test_changelog_historical_range` — verifies `--to` limits commit range to the tagged boundary
- [ ] `test_changelog_no_prior_tag` — verifies full history walk with content assertions
- [ ] `test_changelog_no_prior_tag_json_from_is_null` — verifies JSON `from` is `null`
- [ ] `test_changelog_to_nonexistent_tag_errors` — verifies strict error on missing `--to` tag
- [ ] Merge to main and confirm release workflow generates a populated changelog body for `v0.4.0`