### PR TITLE
🐛 Use local flopha for release changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,11 +37,17 @@ jobs:
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install flopha
+      - name: Install Rust
         if: steps.version_check.outputs.should_release == 'true'
-        env:
-          FLOPHA_VERSION: latest
-        run: bash action/install.sh
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build local flopha
+        if: steps.version_check.outputs.should_release == 'true'
+        shell: bash
+        run: |
+          cargo build --release
+          echo "$PWD/target/release" >> "$GITHUB_PATH"
+          target/release/flopha --version
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
## Why

The release workflow generated changelogs with the latest published flopha binary, so newly added CLI flags and commands were unavailable during a new release.

## Changes

- Build the checkout's release binary in `prepare-release`.
- Put `target/release` on `PATH` before changelog generation so release notes use the version being released.