### PR TITLE
✨ Install local flopha binary

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -104,3 +104,31 @@ jobs:
       - name: Verify binary
         shell: bash
         run: flopha --version
+
+  install-local-binary:
+    name: Install local binary
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download flopha binary
+        uses: actions/download-artifact@v4
+        with:
+          name: flopha-linux
+          path: /tmp/flopha-local
+
+      - name: Install local binary
+        shell: bash
+        env:
+          FLOPHA_BINARY: /tmp/flopha-local/flopha
+        run: bash action/install.sh
+
+      - name: Verify binary
+        shell: bash
+        run: |
+          [ "$(command -v flopha)" = "$HOME/.flopha/bin/flopha" ]
+          flopha --version

--- a/action/install.sh
+++ b/action/install.sh
@@ -18,6 +18,18 @@ esac
 
 BIN_DIR="${HOME}/.flopha/bin"
 
+if [ -n "${FLOPHA_BINARY:-}" ]; then
+  mkdir -p "$BIN_DIR"
+  cp "$FLOPHA_BINARY" "$BIN_DIR/flopha"
+  chmod +x "$BIN_DIR/flopha"
+  echo "$BIN_DIR" >> "$GITHUB_PATH"
+
+  export PATH="$BIN_DIR:$PATH"
+  INSTALLED="$(flopha --version)"
+  echo "Installed $INSTALLED from $FLOPHA_BINARY"
+  exit 0
+fi
+
 # Skip download if flopha is already on PATH (e.g. built from source in CI)
 if command -v flopha >/dev/null 2>&1; then
   FOUND="$(command -v flopha)"


### PR DESCRIPTION
## Why

Release automation needs a way to install the binary built from the current checkout instead of downloading the latest published release.

## Changes

- Add `FLOPHA_BINARY` support to `action/install.sh`.
- Copy the provided binary into `~/.flopha/bin/flopha` and add it to `PATH`.
- Cover the local binary install path in the action test workflow.