### PR TITLE
🐛 Install built flopha in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,10 +37,19 @@ jobs:
             echo "should_release=true" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install flopha
+      - name: Install Rust
+        if: steps.version_check.outputs.should_release == 'true'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build flopha
+        if: steps.version_check.outputs.should_release == 'true'
+        shell: bash
+        run: cargo build --release
+
+      - name: Install local flopha
         if: steps.version_check.outputs.should_release == 'true'
         env:
-          FLOPHA_VERSION: latest
+          FLOPHA_BINARY: ${{ github.workspace }}/target/release/flopha
         run: bash action/install.sh
 
       - name: Generate changelog


### PR DESCRIPTION
## Why

The release workflow currently downloads the latest published flopha binary before generating release notes, so new CLI features from the current checkout are unavailable during the release that introduces them.

## Changes

- Build the current checkout before changelog generation.
- Install that built binary through `action/install.sh` using `FLOPHA_BINARY`.
- Keep changelog generation on the installed `flopha` binary path instead of the legacy published release.