### PR TITLE
✨ Add semver alias and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
 4.  Use a custom version pattern:
 
     ```
-    flopha next-version --pattern "desktop@{major}.{minor}.{patch}"
+    flopha next-version --pattern "desktop@{semver}"
     ```
 
 5.  Auto-detect the next bump from conventional commits:
@@ -85,7 +85,7 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
 8.  Create a new version tag:
 
     ```
-    flopha next-version --pattern "desktop@{major}.{minor}.{patch}" --create
+    flopha next-version --pattern "desktop@{semver}" --create
     ```
 
 9.  Increment major version:
@@ -138,9 +138,10 @@ Aliases: `nv`
 
 - `--rule <LEVEL:PATTERN>`: Define custom bump rules used with `--auto`. Repeatable. When any `--rule` flags are provided, they replace the built-in conventional commit rules entirely.
 
-- `-p`, `--pattern <PATTERN>`: Specify a custom pattern for version matching and generation. Use placeholders `{major}`, `{minor}`, and `{patch}`. Example patterns:
+- `-p`, `--pattern <PATTERN>`: Specify a custom pattern for version matching and generation. Use placeholders `{major}`, `{minor}`, and `{patch}`, or `{semver}` as shorthand for `{major}.{minor}.{patch}`. Example patterns:
 
   - `v{major}.{minor}.{patch}`
+  - `mobile@{semver}`
   - `release-{major}.{minor}.{patch}`
 
 - `--pre <CHANNEL>`: Format the next version as a pre-release on the given channel. Example: `--pre alpha` produces `v1.2.3-alpha.1`.
@@ -159,7 +160,7 @@ Aliases: `lv`
 
 #### Options
 
-- `-p`, `--pattern <PATTERN>`: Get the last version based on a given pattern (e.g., `v{major}.{minor}.{patch}`).
+- `-p`, `--pattern <PATTERN>`: Get the last version based on a given pattern (e.g., `v{major}.{minor}.{patch}` or `v{semver}`).
 
 - `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
 
@@ -175,7 +176,7 @@ Aliases: `lg`
 
 #### Options
 
-- `-p`, `--pattern <PATTERN>`: Filter versions by a pattern such as `v{major}.{minor}.{patch}`.
+- `-p`, `--pattern <PATTERN>`: Filter versions by a pattern such as `v{major}.{minor}.{patch}` or `v{semver}`.
 
 - `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
 

--- a/README.md
+++ b/README.md
@@ -41,24 +41,39 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
 
 ## Quickstart
 
-| Task | Command |
-|---|---|
-| Get the last version | `flopha last-version` |
-| Check out the last version | `flopha last-version --checkout` |
-| Calculate the next patch version | `flopha next-version` |
-| Use a custom tag pattern | `flopha next-version --pattern "desktop@{semver}"` |
-| Auto-detect the next bump from commits | `flopha next-version --auto` |
-| Override auto-detection rules | `flopha next-version --auto --rule 'major:BREAKING CHANGE' --rule 'minor:^feat'` |
-| Preview a pre-release version | `flopha next-version --pre rc` |
-| Create a new version tag | `flopha next-version --pattern "desktop@{semver}" --create` |
-| Create and push a new tag | `flopha next-version --create --push` |
-| Create an annotated tag | `flopha next-version --create --tag-message "Release v1.2.3"` |
-| Increment the major version | `flopha next-version --increment major` |
-| Use branch-based versioning | `flopha next-version --source branch` |
-| Create a new version branch | `flopha next-version --pattern "release/{semver}" --source branch --create` |
-| Show version history | `flopha log --limit 10` |
-| Generate a changelog | `flopha changelog --pattern "mobile@{semver}" --from mobile@26.33.0 --to mobile@26.34.0` |
-| Write a changelog file for the next version | `flopha changelog --title "Changes in $(flopha next-version)" --output CHANGELOG.md` |
+Run commands inside a Git repository with release tags such as `v1.2.3`.
+
+Check the latest version:
+
+```sh
+flopha last-version
+```
+
+Calculate the next patch version:
+
+```sh
+flopha next-version
+```
+
+Let commit messages decide the bump:
+
+```sh
+flopha next-version --auto
+```
+
+Create the next version in Git:
+
+```sh
+flopha next-version --create
+```
+
+Show recent release history:
+
+```sh
+flopha log --limit 10
+```
+
+For custom tag names like `mobile@1.2.3`, use a pattern such as `mobile@{semver}`. See the command reference below or the [official docs](https://sjquant.github.io/flopha) for release branches, changelogs, pre-releases, and CI examples.
 
 ## CLI Commands
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
 
 ## Docs
 
+- Official docs: https://sjquant.github.io/flopha
 - Website source: `website/`
 - Local preview: `pnpm docs:start`
 - Production build: `pnpm docs:build`

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ Use flopha when you want a lightweight release management tool for Git repositor
 
 ## GitHub Action
 
-Use flopha as a GitHub Action to auto-tag the next semantic version and optionally create a GitHub Release — no setup required.
+Use flopha as a GitHub Action to auto-tag the next semantic version and optionally create a GitHub Release. No setup required.
 
 ```yaml
 - uses: sjquant/flopha@v1
 ```
 
-→ [Full action docs: inputs, outputs, and examples](docs/github-action.md)
+See [Full action docs: inputs, outputs, and examples](docs/github-action.md).
 
 ---
 
@@ -40,96 +40,37 @@ curl -fsSL https://raw.githubusercontent.com/sjquant/flopha/main/scripts/install
 
 ## Quickstart
 
-1.  Get the last version:
-
-    ```
-    flopha last-version
-    ```
-
-2.  Check out to the last version:
-
-    ```
-    flopha last-version --checkout
-    ```
-
-3.  Calculate the next version:
-
-    ```
-    flopha next-version
-    ```
-
-4.  Use a custom version pattern:
-
-    ```
-    flopha next-version --pattern "desktop@{semver}"
-    ```
-
-5.  Auto-detect the next bump from conventional commits:
-
-    ```
-    flopha next-version --auto
-    ```
-
-6.  Override auto-detection with custom rules:
-
-    ```
-    flopha next-version --auto --rule 'major:BREAKING CHANGE' --rule 'minor:^feat'
-    ```
-
-7.  Preview a pre-release version:
-
-    ```
-    flopha next-version --pre rc
-    ```
-
-8.  Create a new version tag:
-
-    ```
-    flopha next-version --pattern "desktop@{semver}" --create
-    ```
-
-9.  Increment major version:
-
-    ```
-    flopha next-version --increment major
-    ```
-
-10.  Use branch-based versioning:
-
-    ```
-    flopha next-version --source branch
-    ```
-
-11.  Create a new version branch:
-
-    ```
-    flopha next-version --pattern "release/{major}.{minor}.{patch}" --source branch --create
-    ```
-
-12.  Show version history:
-
-    ```
-    flopha log --limit 10
-    ```
+| Task | Command |
+|---|---|
+| Get the last version | `flopha last-version` |
+| Check out the last version | `flopha last-version --checkout` |
+| Calculate the next patch version | `flopha next-version` |
+| Use a custom tag pattern | `flopha next-version --pattern "desktop@{semver}"` |
+| Auto-detect the next bump from commits | `flopha next-version --auto` |
+| Override auto-detection rules | `flopha next-version --auto --rule 'major:BREAKING CHANGE' --rule 'minor:^feat'` |
+| Preview a pre-release version | `flopha next-version --pre rc` |
+| Create a new version tag | `flopha next-version --pattern "desktop@{semver}" --create` |
+| Create and push a new tag | `flopha next-version --create --push` |
+| Create an annotated tag | `flopha next-version --create --tag-message "Release v1.2.3"` |
+| Increment the major version | `flopha next-version --increment major` |
+| Use branch-based versioning | `flopha next-version --source branch` |
+| Create a new version branch | `flopha next-version --pattern "release/{semver}" --source branch --create` |
+| Show version history | `flopha log --limit 10` |
+| Generate a changelog | `flopha changelog --pattern "mobile@{semver}" --from mobile@26.33.0 --to mobile@26.34.0` |
+| Write a changelog file for the next version | `flopha changelog --title "Changes in $(flopha next-version)" --output CHANGELOG.md` |
 
 ## CLI Commands
 
 ### NextVersion
 
-Calculates and displays the next version based on the current version in the repository.
+Calculates and displays the next version based on the latest matching tag or branch.
 Aliases: `nv`
 
 #### Options
 
-- `-i`, `--increment <INCREMENT>`: Specify the version part to increment. Options are:
+- `-i`, `--increment <major|minor|patch>`: Explicit bump level. Default: `patch`.
 
-  - `major`
-  - `minor`
-  - `patch`
-
-  Default: `patch`
-
-- `--auto`: Auto-detect the bump level from commit messages since the last tag. This currently works with tag-based versioning. Built-in conventional commit behavior is:
+- `--auto`: Auto-detect the bump level from commit messages since the last version. Built-in conventional commit behavior is:
 
   - `BREAKING CHANGE` or `BREAKING-CHANGE` -> `major`
   - `<type>!:` or `<type>(<scope>)!:` -> `major`
@@ -146,12 +87,15 @@ Aliases: `nv`
 
 - `--pre <CHANNEL>`: Format the next version as a pre-release on the given channel. Example: `--pre alpha` produces `v1.2.3-alpha.1`.
 
-- `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
-
-  - `tag` (default)
-  - `branch`
+- `-s`, `--source <tag|branch>`: Read versions from tags or branches. Default: `tag`.
 
 - `-c`, `--create`: Create the next tag or branch in Git.
+
+- `--tag-message <MESSAGE>`: Create an annotated tag with the given message. Requires `--create` and tag source.
+
+- `--push`: Push the created tag or branch to `origin`. Requires `--create`.
+
+- `-f`, `--format <text|json>`: Output format. Default: `text`.
 
 ### LastVersion
 
@@ -162,12 +106,11 @@ Aliases: `lv`
 
 - `-p`, `--pattern <PATTERN>`: Get the last version based on a given pattern (e.g., `v{major}.{minor}.{patch}` or `v{semver}`).
 
-- `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
-
-  - `tag` (default)
-  - `branch`
+- `-s`, `--source <tag|branch>`: Read versions from tags or branches. Default: `tag`.
 
 - `-c`, `--checkout`: Check out the last matching version.
+
+- `-f`, `--format <text|json>`: Output format. Default: `text`.
 
 ### Log
 
@@ -178,18 +121,58 @@ Aliases: `lg`
 
 - `-p`, `--pattern <PATTERN>`: Filter versions by a pattern such as `v{major}.{minor}.{patch}` or `v{semver}`.
 
-- `-s`, `--source <SOURCE>`: Specify the source for versioning. Options are:
-
-  - `tag` (default)
-  - `branch`
+- `-s`, `--source <tag|branch>`: Read versions from tags or branches. Default: `tag`.
 
   Tag mode provides full timeline metadata. Branch mode still lists matching versions, but tag dates and commit counts are not available.
 
 - `-n`, `--limit <LIMIT>`: Limit the number of versions shown.
 
+- `-f`, `--format <text|json>`: Output format. Default: `text`.
+
+### Changelog
+
+Generates a changelog from commits since the last matching version or a specific starting tag.
+Aliases: `cl`
+
+#### Options
+
+- `--from <TAG>`: Tag to start from. Defaults to the latest version matching `--pattern`.
+
+- `--to <VERSION>`: Upper bound for the changelog. The tag must exist when limiting commit history. Also available as `{to}` in `--title`.
+
+- `-p`, `--pattern <PATTERN>`: Match a custom version format. `{semver}` expands to `{major}.{minor}.{patch}`.
+
+- `-s`, `--source <tag|branch>`: Read versions from tags or branches when resolving the default `--from`. Default: `tag`.
+
+- `--group <TITLE:PATTERN>`: Custom changelog group rule. Repeatable. When any group is provided, it replaces the built-in defaults.
+
+- `--other <TITLE>`: Title for commits that match no group. Pass an empty string to suppress unmatched commits. Default: `Other Changes`.
+
+- `--title <TEMPLATE>`: Heading template. Use `{from}` and `{to}` placeholders.
+
+- `-o`, `--output <FILE>`: Write to a file instead of stdout. Existing content is prepended by default.
+
+- `--overwrite`: Replace the output file instead of prepending.
+
+- `-f`, `--format <text|json>`: Output format. Default: `text`.
+
+Default changelog groups:
+
+| Section | Matched commits |
+|---|---|
+| Breaking Changes | `BREAKING CHANGE`, `BREAKING-CHANGE`, or `type!:` |
+| Features | `feat:` or `feat(scope):` |
+| Bug Fixes | `fix:` or `fix(scope):` |
+| Other Changes | Everything else |
+
 ### Global Options
 
 - `-v`, `--verbose`: Enable verbose output for detailed information.
+
+## Default Behavior
+
+- The CLI fetches from the `origin` remote before resolving versions.
+- The default version pattern is `v{major}.{minor}.{patch}`. Use `v{semver}` as a shorter equivalent.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: 'patch'
   pattern:
-    description: "Tag pattern, e.g. 'v{major}.{minor}.{patch}' or 'app@{major}.{minor}.{patch}'."
+    description: "Tag pattern, e.g. 'v{major}.{minor}.{patch}' or 'app@{semver}'."
     required: false
     default: 'v{major}.{minor}.{patch}'
   pre:

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -20,7 +20,7 @@ flopha treats **Git tags as the authoritative version source**. It is not the ri
 |---|---|---|
 | `auto` | `true` | Detect bump level from conventional commits: `feat`→minor, `feat!`/`BREAKING CHANGE`→major, anything else→patch. |
 | `increment` | `patch` | Bump level when `auto: false`: `major`, `minor`, or `patch`. |
-| `pattern` | `v{major}.{minor}.{patch}` | Tag pattern. Use `{major}`, `{minor}`, `{patch}` as placeholders. |
+| `pattern` | `v{major}.{minor}.{patch}` | Tag pattern. Use `{major}`, `{minor}`, `{patch}` as placeholders, or `{semver}` as shorthand. |
 | `pre` | | Pre-release channel: `alpha`, `beta`, `rc`, etc. Produces tags like `v1.2.3-rc.1`. |
 | `rule` | | Custom bump rules, one per line, as `level:regex`. Replaces built-in conventional-commit defaults entirely. |
 | `create-release` | `false` | Create a GitHub Release for the new tag. |
@@ -108,5 +108,5 @@ steps:
 ```yaml
 - uses: sjquant/flopha@v1
   with:
-    pattern: 'app@{major}.{minor}.{patch}'
+    pattern: 'app@{semver}'
 ```

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -89,7 +89,7 @@ pub struct NextVersionArgs {
     pub pre: Option<String>,
     #[clap(
         help = "Specify a custom pattern for version matching and generation. \
-                Use {major}, {minor}, and {patch} as placeholders. \
+                Use {major}, {minor}, and {patch} as placeholders, or {semver} as shorthand. \
                 Example: 'v{major}.{minor}.{patch}' or 'release-{major}.{minor}.{patch}'",
         long,
         short = 'p'
@@ -135,7 +135,7 @@ pub struct NextVersionArgs {
 #[derive(Args, Debug)]
 pub struct LastVersionArgs {
     #[clap(
-        help = "Get last version based on a given pattern (e.g., 'v{major}.{minor}.{patch}')",
+        help = "Get last version based on a given pattern (e.g., 'v{major}.{minor}.{patch}' or 'v{semver}')",
         long,
         short = 'p'
     )]
@@ -163,7 +163,7 @@ pub struct LastVersionArgs {
 #[derive(Args, Debug)]
 pub struct LogArgs {
     #[clap(
-        help = "Pattern for version matching (e.g., 'v{major}.{minor}.{patch}')",
+        help = "Pattern for version matching (e.g., 'v{major}.{minor}.{patch}' or 'v{semver}')",
         long,
         short = 'p'
     )]
@@ -202,7 +202,7 @@ pub struct ChangelogArgs {
     )]
     pub from: Option<String>,
     #[clap(
-        help = "Pattern for version matching (e.g., 'v{major}.{minor}.{patch}')",
+        help = "Pattern for version matching (e.g., 'v{major}.{minor}.{patch}' or 'v{semver}')",
         long,
         short = 'p'
     )]

--- a/src/service.rs
+++ b/src/service.rs
@@ -1075,6 +1075,40 @@ mod tests {
         changelog(td.path(), &args).unwrap();
     }
 
+    /// It uses `{semver}` to find the changelog baseline version.
+    #[test]
+    fn test_changelog_uses_semver_alias_for_baseline_lookup() {
+        // Given
+        let (td, repo) = testutils::init_repo();
+        let (_remote_td, mut remote) = testutils::init_remote(&repo);
+
+        create_new_remote_tag(&repo, &mut remote, "mobile@26.33.0", false);
+        gitutils::checkout_tag(&repo, "mobile@26.33.0").unwrap();
+        gitutils::commit(&repo, "feat: add mobile checkout").unwrap();
+
+        let output_path = format!("{}/out.txt", td.path().display());
+        let args = ChangelogArgs {
+            from: None,
+            pattern: Some("mobile@{semver}".to_string()),
+            source: VersionSourceName::Tag,
+            group: vec![],
+            other: None,
+            title: None,
+            to: None,
+            overwrite: false,
+            output: Some(output_path.clone()),
+            format: OutputFormat::Text,
+        };
+
+        // When
+        changelog(td.path(), &args).unwrap();
+
+        // Then
+        let content = std::fs::read_to_string(output_path).unwrap();
+        assert!(content.contains("Changelog since mobile@26.33.0"));
+        assert!(content.contains("add mobile checkout"));
+    }
+
     #[test]
     fn test_changelog_historical_range() {
         let (td, repo) = testutils::init_repo();

--- a/src/versioning.rs
+++ b/src/versioning.rs
@@ -3,6 +3,9 @@ use regex::Regex;
 
 use crate::error::FlophaError;
 
+const SEMVER_ALIAS: &str = "{semver}";
+const SEMVER_PATTERN: &str = "{major}.{minor}.{patch}";
+
 /// A single rule that maps a regex pattern (matched against a commit message) to an
 /// [`Increment`] level.  Rules are evaluated with major > minor > patch precedence.
 pub struct BumpRule {
@@ -88,6 +91,7 @@ pub enum Increment {
 
 impl Versioner {
     pub fn new(tags: Vec<String>, pattern: String) -> Self {
+        let pattern = pattern.replace(SEMVER_ALIAS, SEMVER_PATTERN);
         Self { tags, pattern }
     }
 
@@ -301,6 +305,32 @@ mod tests {
         );
     }
 
+    /// It expands `{semver}` when matching versions.
+    #[test]
+    fn test_last_version_with_semver_alias() {
+        // Given
+        let tags = vec![
+            "mobile@26.33.0".to_string(),
+            "mobile@26.34.0".to_string(),
+            "desktop@26.35.0".to_string(),
+        ];
+        let versioner = Versioner::new(tags, "mobile@{semver}".to_string());
+
+        // When
+        let last_version = versioner.last_version();
+
+        // Then
+        assert_eq!(
+            last_version,
+            Some(Version::new(
+                "mobile@26.34.0".to_string(),
+                Some(26),
+                Some(34),
+                Some(0)
+            ))
+        );
+    }
+
     #[test]
     fn test_next_version() {
         let tags = vec![
@@ -359,6 +389,28 @@ mod tests {
         );
         let next_version = versioner.next_version(Increment::Major).unwrap();
         assert_eq!(next_version, None);
+    }
+
+    /// It expands `{semver}` when generating the next version.
+    #[test]
+    fn test_next_version_with_semver_alias() {
+        // Given
+        let tags = vec!["mobile@26.33.0".to_string()];
+        let versioner = Versioner::new(tags, "mobile@{semver}".to_string());
+
+        // When
+        let next_version = versioner.next_version(Increment::Minor).unwrap();
+
+        // Then
+        assert_eq!(
+            next_version,
+            Some(Version::new(
+                "mobile@26.34.0".to_string(),
+                Some(26),
+                Some(34),
+                Some(0)
+            ))
+        );
     }
 
     #[test]

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,6 @@
 # flopha docs
 
-This site is built with [Docusaurus](https://docusaurus.io/) and is intended for GitHub Pages deployment.
+This site is built with [Docusaurus](https://docusaurus.io/) and is published as the official flopha docs at https://sjquant.github.io/flopha.
 
 ## Local development
 

--- a/website/docs/command-reference.mdx
+++ b/website/docs/command-reference.mdx
@@ -15,7 +15,7 @@ flopha last-version [--pattern <pattern>] [--source <tag|branch>] [--checkout] [
 
 Options:
 
-- `--pattern`, `-p`: Match a custom version format.
+- `--pattern`, `-p`: Match a custom version format. `{semver}` expands to `{major}.{minor}.{patch}`.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--checkout`: Check out the resolved version after printing it.
 - `--format`, `-f`: Output format — `text` (default) or `json`.
@@ -42,7 +42,7 @@ Options:
 - `--auto`: Detect the bump from commit messages since the last version.
 - `--rule`: Replace the built-in auto-detection rules. Requires `--auto`.
 - `--pre`: Create a pre-release tag like `-alpha.1` or `-rc.1`.
-- `--pattern`, `-p`: Match and generate a custom version format.
+- `--pattern`, `-p`: Match and generate a custom version format. `{semver}` expands to `{major}.{minor}.{patch}`.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--create`: Create the new tag or branch after printing it.
 - `--format`, `-f`: Output format — `text` (default) or `json`.
@@ -57,7 +57,7 @@ flopha log [--pattern <pattern>] [--source <tag|branch>] [--limit <number>] [--f
 
 Options:
 
-- `--pattern`, `-p`: Match a custom version format.
+- `--pattern`, `-p`: Match a custom version format. `{semver}` expands to `{major}.{minor}.{patch}`.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--limit`, `-n`: Limit the number of rows.
 - `--format`, `-f`: Output format — `text` (default) or `json`.
@@ -84,7 +84,7 @@ Options:
 
 - `--from`: Tag to start from. Defaults to the latest matching tag.
 - `--to`: Target version label (does not need to exist as a tag yet). Exposed as `{to}` in `--title`. Useful for stamping the upcoming version before creating the tag.
-- `--pattern`, `-p`: Match a custom version format.
+- `--pattern`, `-p`: Match a custom version format. `{semver}` expands to `{major}.{minor}.{patch}`.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--group`: Custom group rule as `TITLE:REGEX`. Repeatable. When any `--group` flags are given they replace the built-in defaults entirely. Commits not matching any group are collected under the fallback group.
 - `--other`: Title for commits that match no group. Pass an empty string to suppress them entirely. Default: `"Other Changes"`.
@@ -128,4 +128,4 @@ When no `--group` flags are provided, commits are classified as:
 
 - `--verbose`, `-v` enables debug logging.
 - The CLI fetches from the `origin` remote before resolving versions.
-- The default version pattern is `v{major}.{minor}.{patch}`.
+- The default version pattern is `v{major}.{minor}.{patch}`. Use `v{semver}` as a shorter equivalent.

--- a/website/docs/command-reference.mdx
+++ b/website/docs/command-reference.mdx
@@ -33,6 +33,8 @@ flopha next-version \
   [--pattern <pattern>] \
   [--source <tag|branch>] \
   [--create] \
+  [--tag-message <message>] \
+  [--push] \
   [--format <text|json>]
 ```
 
@@ -45,6 +47,8 @@ Options:
 - `--pattern`, `-p`: Match and generate a custom version format. `{semver}` expands to `{major}.{minor}.{patch}`.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--create`: Create the new tag or branch after printing it.
+- `--tag-message`: Create an annotated tag with the given message. Requires `--create` and tag source.
+- `--push`: Push the created tag or branch to `origin`. Requires `--create`.
 - `--format`, `-f`: Output format — `text` (default) or `json`.
 
 ## `flopha log`

--- a/website/docs/intro.mdx
+++ b/website/docs/intro.mdx
@@ -8,6 +8,8 @@ slug: /
 
 `flopha` is a small Git-focused CLI for repositories that encode releases as semantic versions. It looks at matching tags or branches, resolves the latest version, calculates the next one, and can create the result directly in Git.
 
+The official docs are published at https://sjquant.github.io/flopha.
+
 It is useful when your repository needs more than a one-off `git tag`:
 
 - You release with a custom prefix like `desktop@1.4.2` or `release/1.4.2`.

--- a/website/docs/release-workflows.mdx
+++ b/website/docs/release-workflows.mdx
@@ -47,7 +47,7 @@ flopha next-version --source branch --pattern "release/{major}.{minor}.{patch}" 
 Use `log` to confirm what has already been published:
 
 ```bash
-flopha log --pattern "desktop@{major}.{minor}.{patch}" --limit 20
+flopha log --pattern "desktop@{semver}" --limit 20
 ```
 
 The log output includes the version, the release date, and the number of commits since the previous matching version.

--- a/website/docs/version-patterns.mdx
+++ b/website/docs/version-patterns.mdx
@@ -11,11 +11,13 @@ title: Version Patterns
 - `{minor}`
 - `{patch}`
 
+Use `{semver}` as shorthand for `{major}.{minor}.{patch}`.
+
 ## Common examples
 
 ```bash
 flopha last-version --pattern "v{major}.{minor}.{patch}"
-flopha next-version --pattern "desktop@{major}.{minor}.{patch}"
+flopha next-version --pattern "desktop@{semver}"
 flopha next-version --pattern "release/{major}.{minor}.{patch}" --source branch
 ```
 
@@ -26,6 +28,7 @@ The pattern is converted into a full regular expression internally. Static text 
 That means:
 
 - `desktop@{major}.{minor}.{patch}` matches `desktop@1.3.7`
+- `desktop@{semver}` matches `desktop@1.3.7`
 - `release/{major}.{minor}.{patch}` matches `release/2.0.0`
 - `v1.{minor}.{patch}` scopes operations to the `1.x` line
 

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -21,6 +21,7 @@ const config: Config = {
     locales: ['en'],
   },
   customFields: {
+    docsUrl: 'https://sjquant.github.io/flopha',
     githubUrl: 'https://github.com/sjquant/flopha',
   },
   presets: [
@@ -112,6 +113,10 @@ const config: Config = {
         {
           title: 'Project',
           items: [
+            {
+              label: 'Official docs',
+              href: 'https://sjquant.github.io/flopha',
+            },
             {
               label: 'GitHub',
               href: 'https://github.com/sjquant/flopha',


### PR DESCRIPTION
## Why

Typing `{major}.{minor}.{patch}` for common custom tag prefixes is verbose, especially for monorepo release tags like `mobile@26.34.0`. The README also had numbered-list code fences that rendered incorrectly after item 10 because of Markdown continuation indentation, and the official docs site should be easy to find from the repo.

## Changes

- Add `{semver}` as shorthand for `{major}.{minor}.{patch}` in version patterns.
- Cover matching, next-version generation, and changelog baseline discovery with tests.
- Document the shorthand across CLI help, README, GitHub Action docs, and website docs.
- Simplify the README quickstart into a short beginner flow and keep advanced examples in the command reference/docs.
- Refresh README and website command reference coverage for changelog, output formats, push, and annotated tag options.
- Link the official docs site at https://sjquant.github.io/flopha from the README and docs website source.
