### PR TITLE
📝 Fix changelog --to docs

### DIFF
--- a/website/docs/command-reference.mdx
+++ b/website/docs/command-reference.mdx
@@ -73,7 +73,7 @@ Generate a changelog from commits since the last (or a given) version.
 ```bash
 flopha changelog \
   [--from <tag>] \
-  [--to <version>] \
+  [--to <tag>] \
   [--pattern <pattern>] \
   [--source <tag|branch>] \
   [--group <TITLE:REGEX>] \
@@ -87,12 +87,12 @@ flopha changelog \
 Options:
 
 - `--from`: Tag to start from. Defaults to the latest matching tag.
-- `--to`: Target version label (does not need to exist as a tag yet). Exposed as `{to}` in `--title`. Useful for stamping the upcoming version before creating the tag.
+- `--to`: Existing tag or ref to use as the upper bound for the changelog. The value must exist in Git because it limits which commits are included. It is exposed as `{to}` in `--title`.
 - `--pattern`, `-p`: Match a custom version format. `{semver}` expands to `{major}.{minor}.{patch}`.
 - `--source`, `-s`: Read versions from tags or branches. Default is `tag`.
 - `--group`: Custom group rule as `TITLE:REGEX`. Repeatable. When any `--group` flags are given they replace the built-in defaults entirely. Commits not matching any group are collected under the fallback group.
 - `--other`: Title for commits that match no group. Pass an empty string to suppress them entirely. Default: `"Other Changes"`.
-- `--title`: Heading template. Use `{from}` for the starting tag and `{to}` for the target version. Defaults to `"Changes in {to}"` when `--to` is given, otherwise `"Changelog since {from}"`.
+- `--title`: Heading template. Use `{from}` for the starting tag and `{to}` when `--to` is supplied. Defaults to `"Changes in {to}"` when `--to` is given, otherwise `"Changelog since {from}"`. Use `--title` directly when naming an upcoming version before its tag exists.
 - `--output`, `-o`: Write to a file instead of stdout. By default the new content is **prepended** to any existing file content.
 - `--overwrite`: Replace the output file instead of prepending.
 - `--format`, `-f`: Output format — `text` (default, Markdown) or `json`.

--- a/website/docs/release-workflows.mdx
+++ b/website/docs/release-workflows.mdx
@@ -65,7 +65,7 @@ All flopha commands output plain text by default and `--format json` for machine
 NEXT=$(flopha next-version --auto --format json | jq -r '.version')
 
 # 2. Generate changelog headed with the upcoming version
-flopha changelog --to "$NEXT" --output CHANGELOG.md
+flopha changelog --title "Changes in $NEXT" --output CHANGELOG.md
 
 # 3. Commit the updated changelog
 git add CHANGELOG.md
@@ -76,7 +76,7 @@ flopha next-version --auto --create
 git push origin "$NEXT"
 ```
 
-`--to` stamps the target version into the changelog heading **before** the tag exists, so the commit and the tag refer to the same version string.
+`--title` stamps the upcoming version into the changelog heading before the tag exists. Use `--to` only when limiting the changelog to an existing tag or ref.
 
 ### GitHub Actions — using the action
 
@@ -140,7 +140,7 @@ jobs:
         run: echo "tag=$(flopha next-version --auto --format json | jq -r '.version')" >> $GITHUB_OUTPUT
 
       - name: Generate changelog
-        run: flopha changelog --to "${{ steps.version.outputs.tag }}" --output CHANGELOG.md
+        run: flopha changelog --title "Changes in ${{ steps.version.outputs.tag }}" --output CHANGELOG.md
 
       - name: Commit changelog
         run: |
@@ -168,8 +168,8 @@ flopha next-version --auto --format json | jq -r '.version'
 # List recent releases as JSON array
 flopha log --limit 5 --format json
 
-# Generate changelog as structured data
-flopha changelog --to "v2.0.0" --format json | jq '.groups[].title'
+# Generate changelog as structured data for a historical range
+flopha changelog --from "v1.9.0" --to "v2.0.0" --format json | jq '.groups[].title'
 ```
 
 ### Reusable release script
@@ -183,7 +183,7 @@ set -euo pipefail
 NEXT=$(flopha next-version --auto --format json | jq -r '.version')
 echo "Releasing $NEXT"
 
-flopha changelog --to "$NEXT" --output CHANGELOG.md
+flopha changelog --title "Changes in $NEXT" --output CHANGELOG.md
 git add CHANGELOG.md
 git diff --staged --quiet || git commit -m "chore: release $NEXT"
 git push


### PR DESCRIPTION
## Why

The website documented `flopha changelog --to` as usable for an upcoming version before its tag exists, but the CLI requires `--to` to resolve to an existing tag or ref because it bounds the commit history.

## Changes

- Clarify the command reference so `--to` is documented as an existing upper-bound tag/ref.
- Update release workflow examples to use `--title "Changes in ..."` when naming an upcoming version before tagging.
- Keep `--to` examples scoped to historical ranges between existing versions.

## Verification

- `cargo test test_changelog_to_nonexistent_tag_errors -- --nocapture`
- `pnpm --dir website typecheck`
- `pnpm --dir website build`
